### PR TITLE
Standalone binary groundwork: pyside6-deploy spike and the login window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# pyside6-deploy build output for the spikes in spike_standalone/ -- generated, not source
+spike_standalone/deployment/
+spike_standalone/*.dist/
+spike_standalone/build*.log
+spike_standalone/spike_results.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+__pycache__/
+*.pyc
+
 # pyside6-deploy build output for the spikes in spike_standalone/ -- generated, not source
 spike_standalone/deployment/
 spike_standalone/*.dist/

--- a/pyobs_gui/__main__.py
+++ b/pyobs_gui/__main__.py
@@ -1,0 +1,21 @@
+"""Standalone entry point for an interactive-login pyobs-gui -- bypasses the config-file-driven
+`pyobs` CLI entirely. This is what a compiled binary (see
+specs/plans/gui-widget-plugins-and-packaging.md) targets: no YAML config, no credentials on disk
+unless the user opts into "store password" in the login window.
+"""
+
+from __future__ import annotations
+
+from pyobs.application import Application
+
+from .gui import GUI
+from .login import login_and_build_gui
+
+
+def main() -> None:
+    app = Application(module_factory=login_and_build_gui, loop_module_class=GUI)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyobs_gui/accounts.py
+++ b/pyobs_gui/accounts.py
@@ -1,0 +1,133 @@
+"""Saved XMPP login accounts, persisted via QSettings -- see specs/plans/gui-login-window.md.
+
+Each account has a stable internal id (a uuid4 hex string, generated in add_account()) distinct
+from its jid/label -- both are freely editable via update_account(), and the id (not jid/label) is
+what a stored password gets keyed on in the system keychain, so renaming an account never orphans
+its password. Mirrors pyobs-polaris's SavedAccountsModel, which follows the same rule for the same
+reason.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+from PySide6 import QtCore
+
+_ORGANIZATION = "pyobs"
+_APPLICATION = "pyobs-gui"
+
+
+@dataclass
+class Account:
+    id: str
+    jid: str
+    label: str = ""
+    host: str = ""
+    port: int = 0
+    insecure_skip_tls: bool = False
+
+    @property
+    def display_name(self) -> str:
+        return self.label if self.label else self.jid
+
+
+class SavedAccountsModel:
+    """Saved account list, persisted via QSettings. Password storage is a separate concern --
+    see login.py's use of the `keyring` package, keyed by Account.id."""
+
+    def __init__(self, settings: QtCore.QSettings | None = None) -> None:
+        self._settings = settings if settings is not None else QtCore.QSettings(_ORGANIZATION, _APPLICATION)
+
+    def list_accounts(self) -> list[Account]:
+        accounts = []
+        size = self._settings.beginReadArray("accounts")
+        try:
+            for i in range(size):
+                self._settings.setArrayIndex(i)
+                accounts.append(
+                    Account(
+                        id=str(self._settings.value("id", "")),
+                        jid=str(self._settings.value("jid", "")),
+                        label=str(self._settings.value("label", "")),
+                        host=str(self._settings.value("host", "")),
+                        port=int(self._settings.value("port", 0, type=int)),  # pyrefly: ignore [bad-argument-type]
+                        insecure_skip_tls=bool(self._settings.value("insecure_skip_tls", False, type=bool)),
+                    )
+                )
+        finally:
+            self._settings.endArray()
+        return accounts
+
+    def account_by_id(self, account_id: str) -> Account | None:
+        for account in self.list_accounts():
+            if account.id == account_id:
+                return account
+        return None
+
+    def add_account(
+        self,
+        jid: str,
+        label: str = "",
+        host: str = "",
+        port: int = 0,
+        insecure_skip_tls: bool = False,
+    ) -> str:
+        """Adds a new account and returns its newly generated id."""
+        account = Account(
+            id=uuid.uuid4().hex, jid=jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+        )
+        accounts = self.list_accounts()
+        accounts.append(account)
+        self._write_all(accounts)
+        return account.id
+
+    def update_account(
+        self,
+        account_id: str,
+        jid: str,
+        label: str = "",
+        host: str = "",
+        port: int = 0,
+        insecure_skip_tls: bool = False,
+    ) -> None:
+        """Updates an existing account's fields in place -- the id itself never changes."""
+        accounts = self.list_accounts()
+        for i, account in enumerate(accounts):
+            if account.id == account_id:
+                accounts[i] = Account(
+                    id=account_id, jid=jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+                )
+                break
+        self._write_all(accounts)
+
+    def remove_account(self, account_id: str) -> None:
+        accounts = [a for a in self.list_accounts() if a.id != account_id]
+        self._write_all(accounts)
+
+    def _write_all(self, accounts: list[Account]) -> None:
+        self._settings.beginWriteArray("accounts")
+        try:
+            for i, account in enumerate(accounts):
+                self._settings.setArrayIndex(i)
+                self._settings.setValue("id", account.id)
+                self._settings.setValue("jid", account.jid)
+                self._settings.setValue("label", account.label)
+                self._settings.setValue("host", account.host)
+                self._settings.setValue("port", account.port)
+                self._settings.setValue("insecure_skip_tls", account.insecure_skip_tls)
+        finally:
+            self._settings.endArray()
+
+    @property
+    def last_selected_account_id(self) -> str:
+        """Only remembers which account was last used (to preselect it next launch) -- never
+        implies anything was saved/connected automatically."""
+        return str(self._settings.value("last_selected_account_id", ""))
+
+    @last_selected_account_id.setter
+    def last_selected_account_id(self, value: str) -> None:
+        self._settings.setValue("last_selected_account_id", value)
+
+
+__all__ = ["Account", "SavedAccountsModel"]

--- a/pyobs_gui/accounts.py
+++ b/pyobs_gui/accounts.py
@@ -25,6 +25,7 @@ class Account:
     label: str = ""
     host: str = ""
     port: int = 0
+    use_tls: bool = True
     insecure_skip_tls: bool = False
 
     @property
@@ -52,6 +53,7 @@ class SavedAccountsModel:
                         label=str(self._settings.value("label", "")),
                         host=str(self._settings.value("host", "")),
                         port=int(self._settings.value("port", 0, type=int)),  # pyrefly: ignore [bad-argument-type]
+                        use_tls=bool(self._settings.value("use_tls", True, type=bool)),
                         insecure_skip_tls=bool(self._settings.value("insecure_skip_tls", False, type=bool)),
                     )
                 )
@@ -71,11 +73,18 @@ class SavedAccountsModel:
         label: str = "",
         host: str = "",
         port: int = 0,
+        use_tls: bool = True,
         insecure_skip_tls: bool = False,
     ) -> str:
         """Adds a new account and returns its newly generated id."""
         account = Account(
-            id=uuid.uuid4().hex, jid=jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+            id=uuid.uuid4().hex,
+            jid=jid,
+            label=label,
+            host=host,
+            port=port,
+            use_tls=use_tls,
+            insecure_skip_tls=insecure_skip_tls,
         )
         accounts = self.list_accounts()
         accounts.append(account)
@@ -89,6 +98,7 @@ class SavedAccountsModel:
         label: str = "",
         host: str = "",
         port: int = 0,
+        use_tls: bool = True,
         insecure_skip_tls: bool = False,
     ) -> None:
         """Updates an existing account's fields in place -- the id itself never changes."""
@@ -96,7 +106,13 @@ class SavedAccountsModel:
         for i, account in enumerate(accounts):
             if account.id == account_id:
                 accounts[i] = Account(
-                    id=account_id, jid=jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+                    id=account_id,
+                    jid=jid,
+                    label=label,
+                    host=host,
+                    port=port,
+                    use_tls=use_tls,
+                    insecure_skip_tls=insecure_skip_tls,
                 )
                 break
         self._write_all(accounts)
@@ -115,6 +131,7 @@ class SavedAccountsModel:
                 self._settings.setValue("label", account.label)
                 self._settings.setValue("host", account.host)
                 self._settings.setValue("port", account.port)
+                self._settings.setValue("use_tls", account.use_tls)
                 self._settings.setValue("insecure_skip_tls", account.insecure_skip_tls)
         finally:
             self._settings.endArray()

--- a/pyobs_gui/gui.py
+++ b/pyobs_gui/gui.py
@@ -71,7 +71,7 @@ class GUI(Module, IFitsHeaderBefore):
             module=self,
             comm=self.comm,
             vfs=self.vfs,
-            observer=self.observer,
+            observer=self._observer,
         )
         self._window.show()
 

--- a/pyobs_gui/login.py
+++ b/pyobs_gui/login.py
@@ -1,0 +1,51 @@
+"""Async factory for pyobs.application.Application's module_factory contract -- see
+specs/plans/gui-interactive-login.md and specs/plans/gui-login-window.md.
+
+Shows LoginWindow, waits for Connect, then builds an XmppComm + GUI from the result. Runs inside
+the already-running event loop (see Application._main()), so it can await anything it needs to
+before the module/comm connection exists at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from pyobs.comm.xmpp import XmppComm
+
+from .gui import GUI
+from .loginwindow import LoginWindow
+
+log = logging.getLogger(__name__)
+
+
+async def login_and_build_gui(**gui_kwargs: Any) -> GUI:
+    """Shows the login window, waits for the user to click Connect (or cancels if they close the
+    window instead -- see LoginWindow.closeEvent), then returns a GUI built from the result.
+
+    Args:
+        gui_kwargs: Passed through to GUI(...) (show_shell, show_events, widgets, etc.) --
+            everything except `comm`, which is built here from the login window's result.
+    """
+    window = LoginWindow()
+    window.show()
+    try:
+        request = await window.wait_for_connect()
+    except asyncio.CancelledError:
+        log.info("Login window closed without connecting.")
+        raise
+    finally:
+        window.close()
+
+    log.info("Connecting as %s...", request.jid)
+    comm = XmppComm(
+        jid=request.jid,
+        password=request.password,
+        server=request.server,
+        ignore_cert_errors=request.insecure_skip_tls,
+    )
+    return GUI(comm=comm, **gui_kwargs)
+
+
+__all__ = ["login_and_build_gui"]

--- a/pyobs_gui/login.py
+++ b/pyobs_gui/login.py
@@ -43,6 +43,7 @@ async def login_and_build_gui(**gui_kwargs: Any) -> GUI:
         jid=request.jid,
         password=request.password,
         server=request.server,
+        use_tls=request.use_tls,
         ignore_cert_errors=request.insecure_skip_tls,
     )
     return GUI(comm=comm, **gui_kwargs)

--- a/pyobs_gui/loginwindow.py
+++ b/pyobs_gui/loginwindow.py
@@ -1,0 +1,339 @@
+"""Login window shown before any Module/XmppComm exists -- see specs/plans/gui-login-window.md.
+
+Modeled on pyobs-polaris's LoginWindow.qml: list-left/detail-right, Connect always uses whatever's
+currently in the fields (never implicitly saves), saving an account and storing its password are
+two separate, explicit actions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from .accounts import SavedAccountsModel
+
+log = logging.getLogger(__name__)
+
+_KEYRING_SERVICE = "pyobs-gui"
+
+
+@dataclass
+class ConnectionRequest:
+    """Everything needed to build an XmppComm, built fresh from the visible fields on Connect."""
+
+    jid: str
+    password: str
+    server: str | None
+    insecure_skip_tls: bool
+
+
+def build_connection_request(
+    jid: str,
+    password: str,
+    override_server: bool,
+    host: str,
+    port: str,
+    insecure_skip_tls: bool,
+) -> ConnectionRequest | None:
+    """Builds a ConnectionRequest from raw field values, or None if the required fields (jid,
+    password) aren't filled in. Pulled out of LoginWindow as a plain function so it's testable
+    without constructing any Qt widgets.
+
+    Args:
+        jid: JID field text.
+        password: Password field text.
+        override_server: Whether the "override server address" checkbox is checked.
+        host: Host field text (only used if override_server).
+        port: Port field text (only used if override_server and non-empty).
+        insecure_skip_tls: Whether the "skip TLS certificate verification" checkbox is checked.
+    """
+    jid = jid.strip()
+    if not jid or not password:
+        return None
+
+    server = None
+    if override_server:
+        host = host.strip()
+        port = port.strip()
+        if host:
+            server = f"{host}:{port}" if port else host
+
+    return ConnectionRequest(jid=jid, password=password, server=server, insecure_skip_tls=insecure_skip_tls)
+
+
+class LoginWindow(QtWidgets.QDialog):
+    def __init__(self, accounts: SavedAccountsModel | None = None, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("pyobs - Sign in")
+        self.resize(640, 480)
+
+        self._accounts = accounts if accounts is not None else SavedAccountsModel()
+        self._selected_account_id = ""
+        self._keychain_notice = ""
+
+        loop = asyncio.get_event_loop()
+        self._connect_future: asyncio.Future[ConnectionRequest] = loop.create_future()
+
+        self._build_ui()
+        self._reload_account_list()
+
+        last_id = self._accounts.last_selected_account_id
+        if last_id and self._accounts.account_by_id(last_id) is not None:
+            self._select_account(last_id)
+        else:
+            self._select_account("")
+
+    async def wait_for_connect(self) -> ConnectionRequest:
+        """Waits for the user to click Connect, and returns the resulting request. Cancelled if
+        the window is closed first (see closeEvent)."""
+        return await self._connect_future
+
+    # ── UI construction ──────────────────────────────────────────────────────
+
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QHBoxLayout(self)
+
+        # left: saved accounts list
+        left = QtWidgets.QVBoxLayout()
+        left_label = QtWidgets.QLabel("Accounts")
+        left_label.setStyleSheet("font-weight: bold;")
+        left.addWidget(left_label)
+        self._account_list = QtWidgets.QListWidget()
+        self._account_list.currentItemChanged.connect(self._on_account_list_selection_changed)
+        left.addWidget(self._account_list)
+        self._new_connection_button = QtWidgets.QPushButton("+ New connection")
+        self._new_connection_button.clicked.connect(lambda: self._select_account(""))
+        left.addWidget(self._new_connection_button)
+        left_widget = QtWidgets.QWidget()
+        left_widget.setLayout(left)
+        left_widget.setFixedWidth(220)
+        layout.addWidget(left_widget)
+
+        # right: detail form
+        right = QtWidgets.QVBoxLayout()
+
+        title = QtWidgets.QLabel("pyobs")
+        title.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter)
+        title.setStyleSheet("font-weight: bold; font-size: 16pt;")
+        right.addWidget(title)
+
+        self._status_label = QtWidgets.QLabel("")
+        self._status_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter)
+        right.addWidget(self._status_label)
+
+        self._keychain_notice_label = QtWidgets.QLabel("")
+        self._keychain_notice_label.setStyleSheet("color: orange;")
+        self._keychain_notice_label.setWordWrap(True)
+        self._keychain_notice_label.setVisible(False)
+        right.addWidget(self._keychain_notice_label)
+
+        self._jid_field = QtWidgets.QLineEdit()
+        self._jid_field.setPlaceholderText("JID (e.g. user@example.com)")
+        right.addWidget(self._jid_field)
+
+        self._label_field = QtWidgets.QLineEdit()
+        self._label_field.setPlaceholderText("Label (optional, shown in the list)")
+        right.addWidget(self._label_field)
+
+        self._password_field = QtWidgets.QLineEdit()
+        self._password_field.setPlaceholderText("Password")
+        self._password_field.setEchoMode(QtWidgets.QLineEdit.EchoMode.Password)
+        self._password_field.returnPressed.connect(self._on_connect_clicked)
+        right.addWidget(self._password_field)
+
+        self._skip_tls_checkbox = QtWidgets.QCheckBox("Skip TLS certificate verification (insecure, dev only)")
+        right.addWidget(self._skip_tls_checkbox)
+
+        self._store_password_checkbox = QtWidgets.QCheckBox("Store password in system keychain")
+        right.addWidget(self._store_password_checkbox)
+
+        self._override_server_checkbox = QtWidgets.QCheckBox("Override server address (skip DNS SRV lookup)")
+        self._override_server_checkbox.toggled.connect(self._on_override_server_toggled)
+        right.addWidget(self._override_server_checkbox)
+
+        server_row = QtWidgets.QHBoxLayout()
+        self._host_field = QtWidgets.QLineEdit()
+        self._host_field.setPlaceholderText("Host (e.g. example.com)")
+        server_row.addWidget(self._host_field)
+        self._port_field = QtWidgets.QLineEdit()
+        self._port_field.setPlaceholderText("5222")
+        self._port_field.setValidator(QtGui.QIntValidator(1, 65535))
+        self._port_field.setFixedWidth(80)
+        server_row.addWidget(self._port_field)
+        self._server_row_widget = QtWidgets.QWidget()
+        self._server_row_widget.setLayout(server_row)
+        self._server_row_widget.setVisible(False)
+        right.addWidget(self._server_row_widget)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self._save_button = QtWidgets.QPushButton("Save as new account")
+        self._save_button.clicked.connect(self._on_save_clicked)
+        button_row.addWidget(self._save_button)
+        self._delete_button = QtWidgets.QPushButton("Delete")
+        self._delete_button.setVisible(False)
+        self._delete_button.clicked.connect(self._on_delete_clicked)
+        button_row.addWidget(self._delete_button)
+        right.addLayout(button_row)
+
+        right.addStretch()
+
+        self._connect_button = QtWidgets.QPushButton("Connect")
+        self._connect_button.clicked.connect(self._on_connect_clicked)
+        right.addWidget(self._connect_button)
+
+        layout.addLayout(right)
+
+    # ── account list / selection ─────────────────────────────────────────────
+
+    def _reload_account_list(self) -> None:
+        self._account_list.blockSignals(True)
+        self._account_list.clear()
+        for account in self._accounts.list_accounts():
+            item = QtWidgets.QListWidgetItem(account.display_name)
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, account.id)
+            self._account_list.addItem(item)
+        self._account_list.blockSignals(False)
+
+    def _on_account_list_selection_changed(
+        self, current: QtWidgets.QListWidgetItem | None, previous: QtWidgets.QListWidgetItem | None
+    ) -> None:
+        account_id = current.data(QtCore.Qt.ItemDataRole.UserRole) if current is not None else ""
+        self._select_account(account_id or "")
+
+    def _select_account(self, account_id: str) -> None:
+        self._selected_account_id = account_id
+        self._password_field.setText("")
+
+        if not account_id:
+            self._jid_field.setText("")
+            self._label_field.setText("")
+            self._store_password_checkbox.setChecked(False)
+            self._override_server_checkbox.setChecked(False)
+            self._host_field.setText("")
+            self._port_field.setText("")
+            self._skip_tls_checkbox.setChecked(False)
+            self._delete_button.setVisible(False)
+            self._save_button.setText("Save as new account")
+            return
+
+        account = self._accounts.account_by_id(account_id)
+        if account is None:
+            return
+
+        self._jid_field.setText(account.jid)
+        self._label_field.setText(account.label)
+        self._override_server_checkbox.setChecked(bool(account.host))
+        self._host_field.setText(account.host)
+        self._port_field.setText(str(account.port) if account.port else "")
+        self._skip_tls_checkbox.setChecked(account.insecure_skip_tls)
+        self._delete_button.setVisible(True)
+        self._save_button.setText("Save changes")
+
+        import keyring
+
+        try:
+            password = keyring.get_password(_KEYRING_SERVICE, account_id)
+        except Exception:
+            log.exception("Could not read password from system keychain.")
+            password = None
+        self._store_password_checkbox.setChecked(password is not None)
+        if password is not None:
+            self._password_field.setText(password)
+
+    def _on_override_server_toggled(self, checked: bool) -> None:
+        self._server_row_widget.setVisible(checked)
+
+    # ── save / delete ─────────────────────────────────────────────────────────
+
+    def _on_save_clicked(self) -> None:
+        jid = self._jid_field.text().strip()
+        if not jid:
+            return
+        label = self._label_field.text().strip()
+        host = self._host_field.text().strip() if self._override_server_checkbox.isChecked() else ""
+        port_text = self._port_field.text().strip() if self._override_server_checkbox.isChecked() else ""
+        port = int(port_text) if port_text else 0
+        insecure_skip_tls = self._skip_tls_checkbox.isChecked()
+
+        if self._selected_account_id:
+            account_id = self._selected_account_id
+            self._accounts.update_account(
+                account_id, jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+            )
+        else:
+            account_id = self._accounts.add_account(
+                jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+            )
+            self._selected_account_id = account_id
+
+        self._set_stored_password(account_id, self._store_password_checkbox.isChecked())
+        self._reload_account_list()
+        self._select_list_item_by_account_id(account_id)
+
+    def _on_delete_clicked(self) -> None:
+        if not self._selected_account_id:
+            return
+        self._set_stored_password(self._selected_account_id, False)
+        self._accounts.remove_account(self._selected_account_id)
+        self._reload_account_list()
+        self._select_account("")
+
+    def _set_stored_password(self, account_id: str, store: bool) -> None:
+        import keyring
+
+        self._keychain_notice = ""
+        self._keychain_notice_label.setVisible(False)
+        try:
+            if store and self._password_field.text():
+                keyring.set_password(_KEYRING_SERVICE, account_id, self._password_field.text())
+            elif not store:
+                try:
+                    keyring.delete_password(_KEYRING_SERVICE, account_id)
+                except keyring.errors.PasswordDeleteError:
+                    pass  # nothing stored to delete -- not an error
+        except Exception:
+            log.exception("Could not update password in system keychain.")
+            action = "save" if store else "remove"
+            self._keychain_notice = f"Could not {action} the password in the system keychain."
+            self._keychain_notice_label.setText(self._keychain_notice)
+            self._keychain_notice_label.setVisible(True)
+
+    def _select_list_item_by_account_id(self, account_id: str) -> None:
+        for i in range(self._account_list.count()):
+            item = self._account_list.item(i)
+            if item.data(QtCore.Qt.ItemDataRole.UserRole) == account_id:
+                self._account_list.setCurrentItem(item)
+                return
+
+    # ── connect ───────────────────────────────────────────────────────────────
+
+    def _on_connect_clicked(self) -> None:
+        request = build_connection_request(
+            jid=self._jid_field.text(),
+            password=self._password_field.text(),
+            override_server=self._override_server_checkbox.isChecked(),
+            host=self._host_field.text(),
+            port=self._port_field.text(),
+            insecure_skip_tls=self._skip_tls_checkbox.isChecked(),
+        )
+        if request is None:
+            return
+
+        if self._selected_account_id:
+            self._accounts.last_selected_account_id = self._selected_account_id
+
+        self._status_label.setText("Connecting...")
+        self._connect_button.setEnabled(False)
+        if not self._connect_future.done():
+            self._connect_future.set_result(request)
+
+    def closeEvent(self, event: object) -> None:  # noqa: N802  (Qt override, not our naming convention)
+        if not self._connect_future.done():
+            self._connect_future.cancel()
+        super().closeEvent(event)  # type: ignore[arg-type]
+
+
+__all__ = ["ConnectionRequest", "LoginWindow", "build_connection_request"]

--- a/pyobs_gui/loginwindow.py
+++ b/pyobs_gui/loginwindow.py
@@ -27,6 +27,7 @@ class ConnectionRequest:
     jid: str
     password: str
     server: str | None
+    use_tls: bool
     insecure_skip_tls: bool
 
 
@@ -36,6 +37,7 @@ def build_connection_request(
     override_server: bool,
     host: str,
     port: str,
+    use_tls: bool,
     insecure_skip_tls: bool,
 ) -> ConnectionRequest | None:
     """Builds a ConnectionRequest from raw field values, or None if the required fields (jid,
@@ -48,7 +50,11 @@ def build_connection_request(
         override_server: Whether the "override server address" checkbox is checked.
         host: Host field text (only used if override_server).
         port: Port field text (only used if override_server and non-empty).
+        use_tls: Whether the "Use SSL/TLS" checkbox is checked. Defaults to True in the UI --
+            XmppComm itself defaults to False (more appropriate for trusted local networks), but
+            a remote/non-technical-facing login window should default to the secure option.
         insecure_skip_tls: Whether the "skip TLS certificate verification" checkbox is checked.
+            Only meaningful when use_tls is also True.
     """
     jid = jid.strip()
     if not jid or not password:
@@ -61,7 +67,9 @@ def build_connection_request(
         if host:
             server = f"{host}:{port}" if port else host
 
-    return ConnectionRequest(jid=jid, password=password, server=server, insecure_skip_tls=insecure_skip_tls)
+    return ConnectionRequest(
+        jid=jid, password=password, server=server, use_tls=use_tls, insecure_skip_tls=insecure_skip_tls
+    )
 
 
 class LoginWindow(QtWidgets.QDialog):
@@ -144,6 +152,11 @@ class LoginWindow(QtWidgets.QDialog):
         self._password_field.returnPressed.connect(self._on_connect_clicked)
         right.addWidget(self._password_field)
 
+        self._use_tls_checkbox = QtWidgets.QCheckBox("Use SSL/TLS")
+        self._use_tls_checkbox.setChecked(True)
+        self._use_tls_checkbox.toggled.connect(self._on_use_tls_toggled)
+        right.addWidget(self._use_tls_checkbox)
+
         self._skip_tls_checkbox = QtWidgets.QCheckBox("Skip TLS certificate verification (insecure, dev only)")
         right.addWidget(self._skip_tls_checkbox)
 
@@ -214,6 +227,7 @@ class LoginWindow(QtWidgets.QDialog):
             self._override_server_checkbox.setChecked(False)
             self._host_field.setText("")
             self._port_field.setText("")
+            self._use_tls_checkbox.setChecked(True)
             self._skip_tls_checkbox.setChecked(False)
             self._delete_button.setVisible(False)
             self._save_button.setText("Save as new account")
@@ -228,6 +242,7 @@ class LoginWindow(QtWidgets.QDialog):
         self._override_server_checkbox.setChecked(bool(account.host))
         self._host_field.setText(account.host)
         self._port_field.setText(str(account.port) if account.port else "")
+        self._use_tls_checkbox.setChecked(account.use_tls)
         self._skip_tls_checkbox.setChecked(account.insecure_skip_tls)
         self._delete_button.setVisible(True)
         self._save_button.setText("Save changes")
@@ -246,6 +261,12 @@ class LoginWindow(QtWidgets.QDialog):
     def _on_override_server_toggled(self, checked: bool) -> None:
         self._server_row_widget.setVisible(checked)
 
+    def _on_use_tls_toggled(self, checked: bool) -> None:
+        # skipping cert verification is meaningless with TLS off
+        self._skip_tls_checkbox.setEnabled(checked)
+        if not checked:
+            self._skip_tls_checkbox.setChecked(False)
+
     # ── save / delete ─────────────────────────────────────────────────────────
 
     def _on_save_clicked(self) -> None:
@@ -256,16 +277,23 @@ class LoginWindow(QtWidgets.QDialog):
         host = self._host_field.text().strip() if self._override_server_checkbox.isChecked() else ""
         port_text = self._port_field.text().strip() if self._override_server_checkbox.isChecked() else ""
         port = int(port_text) if port_text else 0
+        use_tls = self._use_tls_checkbox.isChecked()
         insecure_skip_tls = self._skip_tls_checkbox.isChecked()
 
         if self._selected_account_id:
             account_id = self._selected_account_id
             self._accounts.update_account(
-                account_id, jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+                account_id,
+                jid,
+                label=label,
+                host=host,
+                port=port,
+                use_tls=use_tls,
+                insecure_skip_tls=insecure_skip_tls,
             )
         else:
             account_id = self._accounts.add_account(
-                jid, label=label, host=host, port=port, insecure_skip_tls=insecure_skip_tls
+                jid, label=label, host=host, port=port, use_tls=use_tls, insecure_skip_tls=insecure_skip_tls
             )
             self._selected_account_id = account_id
 
@@ -317,6 +345,7 @@ class LoginWindow(QtWidgets.QDialog):
             override_server=self._override_server_checkbox.isChecked(),
             host=self._host_field.text(),
             port=self._port_field.text(),
+            use_tls=self._use_tls_checkbox.isChecked(),
             insecure_skip_tls=self._skip_tls_checkbox.isChecked(),
         )
         if request is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pyside6>=6.10.1",
     "astroplan>=0.10.1",
     "astropy>=7.0.1,<8",
+    "keyring>=25.6.0,<26",
 ]
 
 [dependency-groups]
@@ -31,6 +32,9 @@ dev = [
     "Sphinx>=8.2.3,<9",
     "types-defusedxml>=0.7.0.20250708",
     "types-python-dateutil>=2.9.0.20250708",
+    "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
+    "pytest-mock>=3.15.1",
 ]
 
 [build-system]
@@ -55,8 +59,11 @@ ignore = ["E203", "E266", "E501", "F403", "E722"]
 [tool.ruff.lint.mccabe]
 max-complexity = 30
 
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+
 [tool.pyrefly]
-project-includes = ["pyobs_gui"]
+project-includes = ["pyobs_gui", "tests"]
 project-excludes = ["**/docs/", "**/qt/"]
 python-version = "3.11.0"
 preset = "legacy"

--- a/spike_standalone/main.py
+++ b/spike_standalone/main.py
@@ -1,0 +1,84 @@
+"""Phase 0 spike for specs/plans/gui-widget-plugins-and-packaging.md.
+
+Minimal, isolated PySide6 + qasync program, meant to be frozen with pyside6-deploy in
+--mode=standalone, to answer three open questions before more is built on top of them:
+
+1. Does pyside6-deploy/Nuitka even produce a working standalone binary for this app shape at all?
+2. Does an external plugin directory (added to sys.path only at runtime, never seen by Nuitka's
+   static analysis) still import correctly from inside the frozen binary?
+3. Do qtawesome (icon fonts) and keyring (backend auto-discovery) survive freezing unmodified?
+
+The plugin directory path is read from an environment variable at *runtime*, deliberately -- this
+mirrors how the real plugin_paths config will work (known only once the binary actually runs, not
+at build time), so Nuitka has no way to have bundled it even if it wanted to.
+
+Non-interactive: does not call app.exec(). Writes results to spike_results.txt next to the
+executable and to stdout, then exits.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+results: dict[str, str] = {}
+
+# --- PySide6 itself survives freezing (create early: qtawesome needs a live QApplication) ---
+try:
+    from PySide6 import QtWidgets
+
+    app = QtWidgets.QApplication(sys.argv)
+    results["pyside6_qapplication"] = "OK"
+except Exception as e:
+    app = None
+    results["pyside6_qapplication"] = f"FAIL: {e!r}"
+
+# --- plugin loading from a directory outside the build entirely ---
+plugin_dir = os.environ.get("SPIKE_PLUGIN_DIR", "")
+if plugin_dir:
+    sys.path.insert(0, plugin_dir)
+
+try:
+    import my_plugin_widget
+
+    results["plugin_import"] = f"OK: {my_plugin_widget.plugin_marker()}"
+except Exception as e:
+    results["plugin_import"] = f"FAIL: {e!r}"
+
+# --- qtawesome icon fonts ---
+try:
+    import qtawesome as qta
+
+    icon = qta.icon("fa5s.camera")
+    results["qtawesome"] = "FAIL: icon isNull" if icon.isNull() else "OK"
+except Exception as e:
+    results["qtawesome"] = f"FAIL: {e!r}"
+
+# --- keyring backend auto-discovery ---
+try:
+    import keyring
+    import keyring.backend
+
+    available = keyring.backend.get_all_keyring()
+    available_str = ", ".join(f"{type(b).__module__}.{type(b).__name__}(prio={b.priority})" for b in available)
+
+    backend = keyring.get_keyring()
+    keyring.set_password("pyobs-gui-spike", "spike-user", "spike-password")
+    pw = keyring.get_password("pyobs-gui-spike", "spike-user")
+    keyring.delete_password("pyobs-gui-spike", "spike-user")
+    roundtrip = "OK" if pw == "spike-password" else f"MISMATCH: got {pw!r}"
+    results["keyring"] = (
+        f"OK: chosen={type(backend).__module__}.{type(backend).__name__}, "
+        f"roundtrip={roundtrip}, available=[{available_str}]"
+    )
+except Exception as e:
+    results["keyring"] = f"FAIL: {e!r}"
+
+out = "\n".join(f"{k}: {v}" for k, v in results.items())
+print(out)
+
+out_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+with open(os.path.join(out_dir, "spike_results.txt"), "w") as f:
+    f.write(out + "\n")
+
+sys.exit(0)

--- a/spike_standalone/pysidedeploy.spec
+++ b/spike_standalone/pysidedeploy.spec
@@ -1,0 +1,97 @@
+[app]
+
+# title of your application
+title = pyobs_gui_standalone_spike
+
+# project root directory. default = The parent directory of input_file
+project_dir = .
+
+# source file entry point path. default = main.py
+input_file = main.py
+
+# directory where the executable output is generated
+exec_directory = .
+
+# path to the project file relative to project_dir
+project_file = 
+
+# application icon
+icon = /home/husser/code/pyobs/pyobs-gui/.venv/lib/python3.13/site-packages/PySide6/scripts/deploy_lib/pyside_icon.jpg
+
+[python]
+
+# python path
+python_path = /home/husser/code/pyobs/pyobs-gui/.venv/bin/python3
+
+# python packages to install
+packages = Nuitka==4.0
+
+# buildozer = for deploying Android application
+android_packages = buildozer==1.5.0,cython==0.29.33
+
+[qt]
+
+# paths to required qml files. comma separated
+# normally all the qml files required by the project are added automatically
+# design studio projects include the qml files using qt resources
+qml_files = 
+
+# excluded qml plugin binaries
+excluded_qml_plugins = 
+
+# qt modules used. comma separated
+modules = Core,DBus,Gui,Widgets
+
+# qt plugins used by the application. only relevant for desktop deployment
+# for qt plugins used in android application see [android][plugins]
+plugins = accessiblebridge,egldeviceintegrations,generic,iconengines,imageformats,platforminputcontexts,platforms,platforms/darwin,platformthemes,styles,wayland-decoration-client,wayland-graphics-integration-client,wayland-shell-integration,xcbglintegrations
+
+[android]
+
+# path to pyside wheel
+wheel_pyside = 
+
+# path to shiboken wheel
+wheel_shiboken = 
+
+# plugins to be copied to libs folder of the packaged application. comma separated
+plugins = 
+
+[nuitka]
+
+# usage description for permissions requested by the app as found in the info.plist file
+# of the app bundle. comma separated
+# eg = extra_args = --show-modules --follow-stdlib
+macos.permissions = 
+
+# mode of using nuitka. accepts standalone or onefile. default = onefile
+mode = standalone
+
+# specify any extra nuitka arguments
+extra_args = --quiet --noinclude-qt-translations --clang
+
+[buildozer]
+
+# build mode
+# possible values = ["aarch64", "armv7a", "i686", "x86_64"]
+# release creates a .aab, while debug creates a .apk
+mode = debug
+
+# path to pyside6 and shiboken6 recipe dir
+recipe_dir = 
+
+# path to extra qt android .jar files to be loaded by the application
+jars_dir = 
+
+# if empty, uses default ndk path downloaded by buildozer
+ndk_path = 
+
+# if empty, uses default sdk path downloaded by buildozer
+sdk_path = 
+
+# other libraries to be loaded at app startup. comma separated.
+local_libs = 
+
+# architecture of deployed platform
+arch = 
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import pytest
+
+# Run headless by default (no DISPLAY needed) -- only if the environment hasn't already picked a
+# platform, so a real display (e.g. local dev) is still used when available.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6 import QtWidgets  # noqa: E402  (must follow the QT_QPA_PLATFORM default above)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qapp() -> QtWidgets.QApplication:
+    """A QApplication is required to construct any QWidget -- session-scoped since only one may
+    exist per process."""
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        app = QtWidgets.QApplication(sys.argv)
+    return app  # type: ignore[return-value]

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,92 @@
+from PySide6 import QtCore
+
+from pyobs_gui.accounts import SavedAccountsModel
+
+
+def make_model(tmp_path) -> SavedAccountsModel:
+    """An ini-backed, per-test-isolated QSettings -- never touches the real user's settings."""
+    settings = QtCore.QSettings(str(tmp_path / "test_accounts.ini"), QtCore.QSettings.Format.IniFormat)
+    return SavedAccountsModel(settings)
+
+
+def test_list_accounts_empty_initially(tmp_path) -> None:
+    model = make_model(tmp_path)
+    assert model.list_accounts() == []
+
+
+def test_add_account_persists_fields(tmp_path) -> None:
+    model = make_model(tmp_path)
+
+    account_id = model.add_account("user@example.com", label="My Telescope", host="1.2.3.4", port=5222)
+
+    accounts = model.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].id == account_id
+    assert accounts[0].jid == "user@example.com"
+    assert accounts[0].label == "My Telescope"
+    assert accounts[0].host == "1.2.3.4"
+    assert accounts[0].port == 5222
+
+
+def test_account_by_id_returns_none_for_unknown_id(tmp_path) -> None:
+    model = make_model(tmp_path)
+    assert model.account_by_id("does-not-exist") is None
+
+
+def test_update_account_keeps_id_stable(tmp_path) -> None:
+    """The whole point of a stable id: renaming jid/label must not change it, since it's what a
+    stored password is keyed on."""
+    model = make_model(tmp_path)
+    account_id = model.add_account("old@example.com", label="Old Label")
+
+    model.update_account(account_id, "new@example.com", label="New Label")
+
+    account = model.account_by_id(account_id)
+    assert account is not None
+    assert account.id == account_id
+    assert account.jid == "new@example.com"
+    assert account.label == "New Label"
+
+
+def test_remove_account(tmp_path) -> None:
+    model = make_model(tmp_path)
+    keep_id = model.add_account("keep@example.com")
+    remove_id = model.add_account("remove@example.com")
+
+    model.remove_account(remove_id)
+
+    accounts = model.list_accounts()
+    assert [a.id for a in accounts] == [keep_id]
+
+
+def test_multiple_accounts_independent(tmp_path) -> None:
+    model = make_model(tmp_path)
+    id1 = model.add_account("one@example.com", label="One")
+    id2 = model.add_account("two@example.com", label="Two")
+
+    model.update_account(id1, "one@example.com", label="One Updated")
+
+    accounts = {a.id: a for a in model.list_accounts()}
+    assert accounts[id1].label == "One Updated"
+    assert accounts[id2].label == "Two"
+
+
+def test_last_selected_account_id_roundtrips(tmp_path) -> None:
+    model = make_model(tmp_path)
+    assert model.last_selected_account_id == ""
+
+    model.last_selected_account_id = "some-id"
+    assert model.last_selected_account_id == "some-id"
+
+
+def test_display_name_falls_back_to_jid(tmp_path) -> None:
+    model = make_model(tmp_path)
+    account_id = model.add_account("user@example.com")
+    account = model.account_by_id(account_id)
+    assert account is not None
+    assert account.display_name == "user@example.com"
+
+    model.update_account(account_id, "user@example.com", label="Friendly Name")
+    account = model.account_by_id(account_id)
+    assert account is not None
+    assert account.display_name == "Friendly Name"

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -17,7 +17,9 @@ def test_list_accounts_empty_initially(tmp_path) -> None:
 def test_add_account_persists_fields(tmp_path) -> None:
     model = make_model(tmp_path)
 
-    account_id = model.add_account("user@example.com", label="My Telescope", host="1.2.3.4", port=5222)
+    account_id = model.add_account(
+        "user@example.com", label="My Telescope", host="1.2.3.4", port=5222, use_tls=False, insecure_skip_tls=True
+    )
 
     accounts = model.list_accounts()
     assert len(accounts) == 1
@@ -26,6 +28,18 @@ def test_add_account_persists_fields(tmp_path) -> None:
     assert accounts[0].label == "My Telescope"
     assert accounts[0].host == "1.2.3.4"
     assert accounts[0].port == 5222
+    assert accounts[0].use_tls is False
+    assert accounts[0].insecure_skip_tls is True
+
+
+def test_add_account_defaults_use_tls_true(tmp_path) -> None:
+    """Secure-by-default for a remote-facing login window, even though XmppComm itself
+    defaults use_tls to False."""
+    model = make_model(tmp_path)
+    account_id = model.add_account("user@example.com")
+    account = model.account_by_id(account_id)
+    assert account is not None
+    assert account.use_tls is True
 
 
 def test_account_by_id_returns_none_for_unknown_id(tmp_path) -> None:

--- a/tests/test_loginwindow.py
+++ b/tests/test_loginwindow.py
@@ -16,23 +16,25 @@ def make_model(tmp_path) -> SavedAccountsModel:
 
 
 def test_build_connection_request_requires_jid_and_password() -> None:
-    assert build_connection_request("", "pw", False, "", "", False) is None
-    assert build_connection_request("user@example.com", "", False, "", "", False) is None
+    assert build_connection_request("", "pw", False, "", "", True, False) is None
+    assert build_connection_request("user@example.com", "", False, "", "", True, False) is None
 
 
 def test_build_connection_request_without_server_override() -> None:
-    request = build_connection_request("user@example.com", "secret", False, "ignored-host", "1234", False)
-    assert request == ConnectionRequest(jid="user@example.com", password="secret", server=None, insecure_skip_tls=False)
+    request = build_connection_request("user@example.com", "secret", False, "ignored-host", "1234", True, False)
+    assert request == ConnectionRequest(
+        jid="user@example.com", password="secret", server=None, use_tls=True, insecure_skip_tls=False
+    )
 
 
 def test_build_connection_request_with_server_override_host_and_port() -> None:
-    request = build_connection_request("user@example.com", "secret", True, "example.com", "5223", False)
+    request = build_connection_request("user@example.com", "secret", True, "example.com", "5223", True, False)
     assert request is not None
     assert request.server == "example.com:5223"
 
 
 def test_build_connection_request_with_server_override_host_only() -> None:
-    request = build_connection_request("user@example.com", "secret", True, "example.com", "", False)
+    request = build_connection_request("user@example.com", "secret", True, "example.com", "", True, False)
     assert request is not None
     assert request.server == "example.com"
 
@@ -40,21 +42,27 @@ def test_build_connection_request_with_server_override_host_only() -> None:
 def test_build_connection_request_override_checked_but_host_blank_gives_no_server() -> None:
     """Matches XmppComm's own default (None -> normal DNS SRV lookup) -- an override checkbox
     with nothing typed in yet must not produce a bogus ":5223" server string."""
-    request = build_connection_request("user@example.com", "secret", True, "", "5223", False)
+    request = build_connection_request("user@example.com", "secret", True, "", "5223", True, False)
     assert request is not None
     assert request.server is None
 
 
 def test_build_connection_request_strips_whitespace_from_jid() -> None:
-    request = build_connection_request("  user@example.com  ", "secret", False, "", "", False)
+    request = build_connection_request("  user@example.com  ", "secret", False, "", "", True, False)
     assert request is not None
     assert request.jid == "user@example.com"
 
 
 def test_build_connection_request_carries_insecure_skip_tls() -> None:
-    request = build_connection_request("user@example.com", "secret", False, "", "", True)
+    request = build_connection_request("user@example.com", "secret", False, "", "", True, True)
     assert request is not None
     assert request.insecure_skip_tls is True
+
+
+def test_build_connection_request_carries_use_tls_false() -> None:
+    request = build_connection_request("user@example.com", "secret", False, "", "", False, False)
+    assert request is not None
+    assert request.use_tls is False
 
 
 # ── LoginWindow ────────────────────────────────────────────────────────────────
@@ -82,7 +90,14 @@ async def test_login_window_lists_saved_accounts(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_login_window_selecting_account_prefills_fields(tmp_path) -> None:
     model = make_model(tmp_path)
-    account_id = model.add_account("user@example.com", label="My Telescope", host="example.com", port=5223)
+    account_id = model.add_account(
+        "user@example.com",
+        label="My Telescope",
+        host="example.com",
+        port=5223,
+        use_tls=False,
+        insecure_skip_tls=True,
+    )
 
     window = LoginWindow(accounts=model)
     window._select_account(account_id)
@@ -92,6 +107,28 @@ async def test_login_window_selecting_account_prefills_fields(tmp_path) -> None:
     assert window._override_server_checkbox.isChecked() is True
     assert window._host_field.text() == "example.com"
     assert window._port_field.text() == "5223"
+    assert window._use_tls_checkbox.isChecked() is False
+    assert window._skip_tls_checkbox.isChecked() is True
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_use_tls_defaults_checked_on_new_connection(tmp_path) -> None:
+    window = LoginWindow(accounts=make_model(tmp_path))
+    assert window._use_tls_checkbox.isChecked() is True
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_unchecking_use_tls_disables_and_unchecks_skip_verification(tmp_path) -> None:
+    """Skipping cert verification is meaningless with TLS off entirely."""
+    window = LoginWindow(accounts=make_model(tmp_path))
+    window._skip_tls_checkbox.setChecked(True)
+
+    window._use_tls_checkbox.setChecked(False)
+
+    assert window._skip_tls_checkbox.isChecked() is False
+    assert window._skip_tls_checkbox.isEnabled() is False
     window.close()
 
 
@@ -104,7 +141,9 @@ async def test_login_window_connect_resolves_wait_for_connect(tmp_path) -> None:
     window._on_connect_clicked()
     request = await asyncio.wait_for(window.wait_for_connect(), timeout=1.0)
 
-    assert request == ConnectionRequest(jid="user@example.com", password="secret", server=None, insecure_skip_tls=False)
+    assert request == ConnectionRequest(
+        jid="user@example.com", password="secret", server=None, use_tls=True, insecure_skip_tls=False
+    )
     window.close()
 
 

--- a/tests/test_loginwindow.py
+++ b/tests/test_loginwindow.py
@@ -1,0 +1,157 @@
+import asyncio
+
+import pytest
+from PySide6 import QtCore
+
+from pyobs_gui.accounts import SavedAccountsModel
+from pyobs_gui.loginwindow import ConnectionRequest, LoginWindow, build_connection_request
+
+
+def make_model(tmp_path) -> SavedAccountsModel:
+    settings = QtCore.QSettings(str(tmp_path / "test_accounts.ini"), QtCore.QSettings.Format.IniFormat)
+    return SavedAccountsModel(settings)
+
+
+# ── build_connection_request (pure logic, no Qt widgets needed) ───────────────
+
+
+def test_build_connection_request_requires_jid_and_password() -> None:
+    assert build_connection_request("", "pw", False, "", "", False) is None
+    assert build_connection_request("user@example.com", "", False, "", "", False) is None
+
+
+def test_build_connection_request_without_server_override() -> None:
+    request = build_connection_request("user@example.com", "secret", False, "ignored-host", "1234", False)
+    assert request == ConnectionRequest(jid="user@example.com", password="secret", server=None, insecure_skip_tls=False)
+
+
+def test_build_connection_request_with_server_override_host_and_port() -> None:
+    request = build_connection_request("user@example.com", "secret", True, "example.com", "5223", False)
+    assert request is not None
+    assert request.server == "example.com:5223"
+
+
+def test_build_connection_request_with_server_override_host_only() -> None:
+    request = build_connection_request("user@example.com", "secret", True, "example.com", "", False)
+    assert request is not None
+    assert request.server == "example.com"
+
+
+def test_build_connection_request_override_checked_but_host_blank_gives_no_server() -> None:
+    """Matches XmppComm's own default (None -> normal DNS SRV lookup) -- an override checkbox
+    with nothing typed in yet must not produce a bogus ":5223" server string."""
+    request = build_connection_request("user@example.com", "secret", True, "", "5223", False)
+    assert request is not None
+    assert request.server is None
+
+
+def test_build_connection_request_strips_whitespace_from_jid() -> None:
+    request = build_connection_request("  user@example.com  ", "secret", False, "", "", False)
+    assert request is not None
+    assert request.jid == "user@example.com"
+
+
+def test_build_connection_request_carries_insecure_skip_tls() -> None:
+    request = build_connection_request("user@example.com", "secret", False, "", "", True)
+    assert request is not None
+    assert request.insecure_skip_tls is True
+
+
+# ── LoginWindow ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_login_window_starts_on_new_connection_form(tmp_path) -> None:
+    window = LoginWindow(accounts=make_model(tmp_path))
+    assert window._jid_field.text() == ""
+    assert window._selected_account_id == ""
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_lists_saved_accounts(tmp_path) -> None:
+    model = make_model(tmp_path)
+    model.add_account("user@example.com", label="My Telescope")
+
+    window = LoginWindow(accounts=model)
+    assert window._account_list.count() == 1
+    assert window._account_list.item(0).text() == "My Telescope"
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_selecting_account_prefills_fields(tmp_path) -> None:
+    model = make_model(tmp_path)
+    account_id = model.add_account("user@example.com", label="My Telescope", host="example.com", port=5223)
+
+    window = LoginWindow(accounts=model)
+    window._select_account(account_id)
+
+    assert window._jid_field.text() == "user@example.com"
+    assert window._label_field.text() == "My Telescope"
+    assert window._override_server_checkbox.isChecked() is True
+    assert window._host_field.text() == "example.com"
+    assert window._port_field.text() == "5223"
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_connect_resolves_wait_for_connect(tmp_path) -> None:
+    window = LoginWindow(accounts=make_model(tmp_path))
+    window._jid_field.setText("user@example.com")
+    window._password_field.setText("secret")
+
+    window._on_connect_clicked()
+    request = await asyncio.wait_for(window.wait_for_connect(), timeout=1.0)
+
+    assert request == ConnectionRequest(jid="user@example.com", password="secret", server=None, insecure_skip_tls=False)
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_connect_with_empty_fields_does_not_resolve(tmp_path) -> None:
+    window = LoginWindow(accounts=make_model(tmp_path))
+    window._on_connect_clicked()  # jid/password both empty
+
+    assert not window._connect_future.done()
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_close_without_connecting_cancels_wait_for_connect(tmp_path) -> None:
+    window = LoginWindow(accounts=make_model(tmp_path))
+    window.close()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(window.wait_for_connect(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_login_window_save_then_select_persists_account(tmp_path) -> None:
+    model = make_model(tmp_path)
+    window = LoginWindow(accounts=model)
+    window._jid_field.setText("user@example.com")
+    window._label_field.setText("My Telescope")
+
+    window._on_save_clicked()
+
+    accounts = model.list_accounts()
+    assert len(accounts) == 1
+    assert accounts[0].jid == "user@example.com"
+    assert accounts[0].label == "My Telescope"
+    assert window._selected_account_id == accounts[0].id
+    window.close()
+
+
+@pytest.mark.asyncio
+async def test_login_window_delete_removes_account(tmp_path) -> None:
+    model = make_model(tmp_path)
+    account_id = model.add_account("user@example.com")
+
+    window = LoginWindow(accounts=model)
+    window._select_account(account_id)
+    window._on_delete_clicked()
+
+    assert model.list_accounts() == []
+    assert window._selected_account_id == ""
+    window.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1133,6 +1133,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "isodate"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1975,6 +1984,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2368,6 +2386,7 @@ dependencies = [
     { name = "astroplan" },
     { name = "astropy" },
     { name = "colour" },
+    { name = "keyring" },
     { name = "matplotlib" },
     { name = "pyobs-core" },
     { name = "pyside6" },
@@ -2386,6 +2405,9 @@ dev = [
     { name = "pre-commit" },
     { name = "pyrefly" },
     { name = "pyside6-stubs" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "sphinx" },
     { name = "sphinx-rtd-theme" },
@@ -2398,6 +2420,7 @@ requires-dist = [
     { name = "astroplan", specifier = ">=0.10.1" },
     { name = "astropy", specifier = ">=7.0.1,<8" },
     { name = "colour", specifier = ">=0.1.5,<0.2" },
+    { name = "keyring", specifier = ">=25.6.0,<26" },
     { name = "matplotlib", specifier = ">=3.10.1,<4" },
     { name = "pyobs-core", specifier = ">=2.0.0.dev28,<3" },
     { name = "pyside6", specifier = ">=6.10.1" },
@@ -2415,6 +2438,9 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
     { name = "pyrefly", specifier = ">=0.17.0" },
     { name = "pyside6-stubs", specifier = ">=6.7.3.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "sphinx", specifier = ">=8.2.3,<9" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<4" },
@@ -2509,6 +2535,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/2b/d2a3fdb212475682b11e8b6330f2cada60dcbbaf151f73f86844b11d1db6/pyside6_stubs-6.7.3.0.tar.gz", hash = "sha256:db8def2bb9c74091bfa2a4df7610d3ea344ecd00ebd4283995eeb5fda8383603", size = 509931, upload-time = "2025-03-04T05:49:15.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/2e/3488fa3baca56ff494b9502424675f5b14b11e966eb74d5adaf1811cd651/pyside6_stubs-6.7.3.0-py3-none-any.whl", hash = "sha256:7a2ef0d7486939f240e745829f80887ec3eab280e52c9930d64b48b3de95042a", size = 550616, upload-time = "2025-03-04T05:49:13.154Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Groundwork for shipping pyobs-gui as a standalone binary (see `pyobs-core/specs/design/gui-standalone-binary.md`):
- Phase 0 spike: a `pyside6-deploy` standalone build for the plugin mechanism.
- The login window itself (`gui-login-window.md`), replacing the current config-file-upfront requirement, plus a "Use SSL/TLS" checkbox found missing while dogfooding it.
- Fixes a GUI startup crash when no observer is configured.

Depends on the matching `feature/standalone-binary` branch in `pyobs-core` (module-factory support for this login flow) — see pyobs/pyobs-core#701.

## Test plan
- [ ] Existing test suite passes
- [ ] Manually exercise the login window: launch with no config, log in, confirm the GUI starts correctly
- [ ] Confirm behavior with the observer-not-configured fix