### PR TITLE
Catch exceptions on remote method calls and show them in a messagebox (fixes #134)

### DIFF
--- a/pyobs_gui/acquisitionwidget.py
+++ b/pyobs_gui/acquisitionwidget.py
@@ -2,7 +2,6 @@ import logging
 import os
 from typing import Any
 
-import qasync  # type: ignore
 from PySide6 import QtCore, QtWidgets  # type: ignore
 
 os.environ["QT_API"] = "PySide6"
@@ -147,13 +146,17 @@ class AcquisitionWidget(BaseWidget, Ui_AcquisitionWidget):
 
         self.canvas.draw()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _acquire(self) -> None:
+    def _acquire(self) -> None:
+        self.run_background(self._acquire_target)
+
+    async def _acquire_target(self) -> None:
         async with self.comm.proxy(self.module, IAcquisition) as proxy:
             await proxy.acquire_target()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _abort(self) -> None:
+    def _abort(self) -> None:
+        self.run_background(self._abort_acquisition)
+
+    async def _abort_acquisition(self) -> None:
         async with self.comm.proxy(self.module, IAcquisition) as proxy:
             await proxy.abort()
 

--- a/pyobs_gui/autofocuswidget.py
+++ b/pyobs_gui/autofocuswidget.py
@@ -2,7 +2,6 @@ import logging
 import os
 from typing import Any
 
-import qasync  # type: ignore
 from PySide6 import QtCore, QtWidgets  # type: ignore
 
 os.environ["QT_API"] = "PySide6"
@@ -78,9 +77,7 @@ class AutoFocusWidget(BaseWidget, Ui_AutoFocusWidget):
         self.labelStatus.setText(
             "Running..."
             if self._running
-            else f"Focus: {self._last_result[0]:.3f} ± {self._last_result[1]:.3f} mm"
-            if self._last_result
-            else "Idle"
+            else f"Focus: {self._last_result[0]:.3f} ± {self._last_result[1]:.3f} mm" if self._last_result else "Idle"
         )
 
         self.ax.clear()
@@ -95,13 +92,19 @@ class AutoFocusWidget(BaseWidget, Ui_AutoFocusWidget):
         self.ax.set_axisbelow(True)
         self.canvas.draw()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _run_auto_focus(self) -> None:
-        async with self.comm.proxy(self.module, IAutoFocus) as proxy:
-            await proxy.auto_focus(self.spinCount.value(), self.spinStep.value(), self.spinExposureTime.value())
+    def _run_auto_focus(self) -> None:
+        self.run_background(
+            self._auto_focus, self.spinCount.value(), self.spinStep.value(), self.spinExposureTime.value()
+        )
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _abort(self) -> None:
+    async def _auto_focus(self, count: int, step: float, exposure_time: float) -> None:
+        async with self.comm.proxy(self.module, IAutoFocus) as proxy:
+            await proxy.auto_focus(count, step, exposure_time)
+
+    def _abort(self) -> None:
+        self.run_background(self._abort_focus)
+
+    async def _abort_focus(self) -> None:
         async with self.comm.proxy(self.module, IAutoFocus) as proxy:
             await proxy.abort()
 

--- a/pyobs_gui/autoguidingwidget.py
+++ b/pyobs_gui/autoguidingwidget.py
@@ -4,7 +4,6 @@ import os
 from collections import deque
 from typing import Any
 
-import qasync  # type: ignore
 from PySide6 import QtCore, QtWidgets  # type: ignore
 
 os.environ["QT_API"] = "PySide6"
@@ -130,19 +129,25 @@ class AutoGuidingWidget(BaseWidget, Ui_AutoGuidingWidget):
         self.figure.tight_layout()
         self.canvas.draw()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _start(self) -> None:
+    def _start(self) -> None:
+        self.run_background(self._start_guiding)
+
+    async def _start_guiding(self) -> None:
         async with self.comm.proxy(self.module, IAutoGuiding) as proxy:
             await proxy.start()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _stop(self) -> None:
+    def _stop(self) -> None:
+        self.run_background(self._stop_guiding)
+
+    async def _stop_guiding(self) -> None:
         async with self.comm.proxy(self.module, IAutoGuiding) as proxy:
             await proxy.stop()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _set_exposure_time(self) -> None:
+    def _set_exposure_time(self) -> None:
         value = self.spinExposureTime.value()
+        self.run_background(self._set_exposure_time_async, value)
+
+    async def _set_exposure_time_async(self, value: float) -> None:
         async with self.comm.proxy(self.module, IExposureTime) as proxy:
             await proxy.set_exposure_time(value)
 

--- a/pyobs_gui/base.py
+++ b/pyobs_gui/base.py
@@ -36,7 +36,9 @@ async def show_remote_error(parent: QtWidgets.QWidget, exception: Exception) -> 
     `run_background()`) and by non-`BaseWidget` callers like `StatusItem`.
     """
     if isinstance(exception, exc.PyobsError):
-        await QAsyncMessageBox.warning(parent, type(exception).__name__, str(exception))
+        # PyobsError.__str__ already prefixes the class name ("<MoveError> msg"); the class name
+        # is the dialog title, so show only the message itself
+        await QAsyncMessageBox.warning(parent, type(exception).__name__, exception.message or str(exception))
     else:
         log.exception("An error occurred.")
         await QAsyncMessageBox.warning(parent, "Error", str(exception))
@@ -136,7 +138,6 @@ class BaseWindow:
 
 
 class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
-    _show_error = QtCore.Signal(str)
     _enable_buttons = QtCore.Signal(list, bool)
 
     def __init__(
@@ -150,7 +151,6 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
         QtWidgets.QWidget.__init__(self)
 
         # signals
-        self._show_error.connect(self.show_error)
         self._enable_buttons.connect(self.enable_buttons)
 
         # update
@@ -311,7 +311,7 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
                 # background polling failures must not pop a dialog per failed poll -- log the
                 # first failure, then every 60th (~once a minute at the 1s poll interval)
                 consecutive_failures += 1
-                if consecutive_failures == 1 or consecutive_failures % 60 == 0:
+                if consecutive_failures % 60 == 1:
                     log.warning("Update of %s failed: %s", self.module, e)
                 await asyncio.sleep(1)
 
@@ -335,9 +335,6 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
         finally:
             # enable widgets
             self._enable_buttons.emit(disable, True)
-
-    async def show_error(self, exception: exc.PyobsError) -> None:
-        await show_remote_error(self, exception)
 
     def enable_buttons(self, widgets: list[QtWidgets.QWidget], enable: bool) -> None:
         for w in widgets:

--- a/pyobs_gui/base.py
+++ b/pyobs_gui/base.py
@@ -26,6 +26,22 @@ log = logging.getLogger(__name__)
 WidgetClass = TypeVar("WidgetClass", bound="BaseWidget")
 
 
+async def show_remote_error(parent: QtWidgets.QWidget, exception: Exception) -> None:
+    """Show a remote-call failure to the user.
+
+    Single shared path for surfacing exceptions from remote method calls: `PyobsError`
+    (domain errors like `MoveError`, and transport errors like `RemoteError`) shows a warning
+    box titled with the exception class; any other `Exception` is logged and shown as a plain
+    warning. Used by `BaseWidget._background_task()` (everything routed through
+    `run_background()`) and by non-`BaseWidget` callers like `StatusItem`.
+    """
+    if isinstance(exception, exc.PyobsError):
+        await QAsyncMessageBox.warning(parent, type(exception).__name__, str(exception))
+    else:
+        log.exception("An error occurred.")
+        await QAsyncMessageBox.warning(parent, "Error", str(exception))
+
+
 class BaseWindow:
     def __init__(self) -> None:
         """Base class for MainWindow and all widgets."""
@@ -271,6 +287,7 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
                 self._update_task = None
 
     async def _update_loop(self) -> None:
+        consecutive_failures = 0
         while True:
             try:
                 # get module state
@@ -288,9 +305,14 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
 
                 # sleep a little
                 await asyncio.sleep(1)
+                consecutive_failures = 0
 
-            except (exc.PyobsError, IndexError):
-                # ignore these and sleep a little
+            except (exc.PyobsError, IndexError) as e:
+                # background polling failures must not pop a dialog per failed poll -- log the
+                # first failure, then every 60th (~once a minute at the 1s poll interval)
+                consecutive_failures += 1
+                if consecutive_failures == 1 or consecutive_failures % 60 == 0:
+                    log.warning("Update of %s failed: %s", self.module, e)
                 await asyncio.sleep(1)
 
     def run_background(self, method: Callable[..., Coroutine[Any, Any, None]], *args: Any, **kwargs: Any) -> None:
@@ -308,19 +330,14 @@ class BaseWidget(BaseWindow, QtWidgets.QWidget):  # type: ignore
         # call method
         try:
             await method(*args, **kwargs)
-        except exc.PyobsError as e:
-            await self.show_error(e)
         except Exception as e:
-            log.exception("An error occurred.")
-            await QAsyncMessageBox.warning(self, "Error", str(e))
+            await show_remote_error(self, e)
         finally:
             # enable widgets
             self._enable_buttons.emit(disable, True)
 
     async def show_error(self, exception: exc.PyobsError) -> None:
-        err = str(exception)
-        title, message = err.split(":") if ":" in err else ("Error", err)
-        await QAsyncMessageBox.warning(self, title, message)
+        await show_remote_error(self, exception)
 
     def enable_buttons(self, widgets: list[QtWidgets.QWidget], enable: bool) -> None:
         for w in widgets:

--- a/pyobs_gui/camerawidget.py
+++ b/pyobs_gui/camerawidget.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any
-import qasync  # type: ignore
 from PySide6 import QtWidgets, QtCore  # type: ignore
 from astroplan import Observer
 
@@ -225,8 +224,10 @@ class CameraWidget(BaseWidget, Ui_CameraWidget):
         self.exposures_left = state.count_left
         self.update_gui()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def set_full_frame(self) -> None:
+    def set_full_frame(self) -> None:
+        self.run_background(self._do_set_full_frame)
+
+    async def _do_set_full_frame(self) -> None:
         caps = await self.comm.get_capabilities(self.module, IWindow)
         if caps is not None:
             # get binning
@@ -268,18 +269,15 @@ class CameraWidget(BaseWidget, Ui_CameraWidget):
         else:
             self.spinExpTime.setEnabled(True)
 
-    @qasync.asyncSlot()  # type: ignore
-    async def expose(self) -> None:
+    def expose(self) -> None:
+        self.run_background(self._do_expose)
+
+    async def _do_expose(self) -> None:
         # set binning
         async with self.comm.safe_proxy(self.module, IBinning) as proxy:
             if proxy is not None:
                 binning = int(self.comboBinning.currentText()[0])
-                try:
-                    await proxy.set_binning(binning, binning)
-                except Exception:
-                    log.exception("bla")
-                    QtWidgets.QMessageBox.information(self, "Error", "Could not set binning.")
-                    return
+                await proxy.set_binning(binning, binning)
             else:
                 binning = 1
 
@@ -288,11 +286,7 @@ class CameraWidget(BaseWidget, Ui_CameraWidget):
             if proxy is not None:
                 left, top = self.spinWindowLeft.value(), self.spinWindowTop.value()
                 width, height = self.spinWindowWidth.value(), self.spinWindowHeight.value()
-                try:
-                    await proxy.set_window(left, top, width * binning, height * binning)
-                except Exception:
-                    QtWidgets.QMessageBox.information(self, "Error", "Could not set window.")
-                    return
+                await proxy.set_window(left, top, width * binning, height * binning)
 
         # set image format
         async with self.comm.safe_proxy(self.module, IImageFormat) as proxy:
@@ -348,13 +342,15 @@ class CameraWidget(BaseWidget, Ui_CameraWidget):
             self.exposures_left -= 1
             self.signal_update_gui.emit()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def abort(self) -> None:
+    def abort(self) -> None:
         """Abort exposure."""
         # do we have a running exposure?
         if self.exposures_left == 0:
             return
 
+        self.run_background(self._do_abort)
+
+    async def _do_abort(self) -> None:
         # got exposures left?
         if self.exposures_left > 1:
             # soft-stop the sequence server-side (current grab finishes normally), if

--- a/pyobs_gui/coolingwidget.py
+++ b/pyobs_gui/coolingwidget.py
@@ -1,4 +1,3 @@
-import qasync
 import logging
 from typing import Any
 from PySide6 import QtCore  # type: ignore
@@ -47,9 +46,11 @@ class CoolingWidget(BaseWidget, Ui_CoolingWidget):
     def checkEnabled_toggled(self, enabled: bool) -> None:
         self.spinSetPoint.setEnabled(enabled)
 
-    @qasync.asyncSlot()  # type: ignore
-    async def buttonApply_clicked(self) -> None:
+    def buttonApply_clicked(self) -> None:
         enabled = self.checkEnabled.isChecked()
         temp = self.spinSetPoint.value()
+        self.run_background(self._apply_cooling, enabled, temp)
+
+    async def _apply_cooling(self, enabled: bool, temp: float) -> None:
         async with self.comm.proxy(self.module, ICooling) as proxy:
             await proxy.set_cooling(enabled, temp)

--- a/pyobs_gui/datadisplaywidget.py
+++ b/pyobs_gui/datadisplaywidget.py
@@ -20,7 +20,6 @@ from .qt.datadisplaywidget_ui import Ui_DataDisplayWidget
 
 if TYPE_CHECKING:
     from matplotlib.figure import Figure
-    from pyobs.comm import Proxy
     from matplotlib.axes import Axes
     from astropy.io import fits
 

--- a/pyobs_gui/filterwidget.py
+++ b/pyobs_gui/filterwidget.py
@@ -60,7 +60,6 @@ class FilterWidget(BaseWidget, Ui_FilterWidget):
         ]
         self.buttonSetFilter.setEnabled(initialized and self.permitted("set_filter"))
 
-    @QtCore.Slot()  # type: ignore
     def set_filter(self) -> None:
         new_value, ok = QtWidgets.QInputDialog.getItem(self, "Set filter", "New filter", self._filters, 0, False)
         if ok:

--- a/pyobs_gui/filterwidget.py
+++ b/pyobs_gui/filterwidget.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import qasync
 from PySide6 import QtWidgets, QtCore  # type: ignore
 
 from pyobs.interfaces import IFilters, FilterState, IMotion, MotionState
@@ -61,12 +60,16 @@ class FilterWidget(BaseWidget, Ui_FilterWidget):
         ]
         self.buttonSetFilter.setEnabled(initialized and self.permitted("set_filter"))
 
-    @qasync.asyncSlot()  # type: ignore
-    async def set_filter(self) -> None:
+    @QtCore.Slot()  # type: ignore
+    def set_filter(self) -> None:
         new_value, ok = QtWidgets.QInputDialog.getItem(self, "Set filter", "New filter", self._filters, 0, False)
         if ok:
-            async with self.comm.proxy(self.module, IFilters) as proxy:
-                self.run_background(proxy.set_filter, new_value)
+
+            async def _do_set_filter() -> None:
+                async with self.comm.proxy(self.module, IFilters) as proxy:
+                    await proxy.set_filter(new_value)
+
+            self.run_background(_do_set_filter)
 
 
 __all__ = ["FilterWidget"]

--- a/pyobs_gui/focuswidget.py
+++ b/pyobs_gui/focuswidget.py
@@ -1,8 +1,6 @@
-import asyncio
 import logging
 from typing import Any
 
-import qasync  # type: ignore
 from PySide6 import QtWidgets, QtCore  # type: ignore
 
 from pyobs.interfaces import IFocuser, FocuserState, IMotion, MotionState
@@ -71,7 +69,7 @@ class FocusWidget(BaseWidget, Ui_FocusWidget):
         value = self._focus or 0.0
         new_value, ok = QtWidgets.QInputDialog.getDouble(self, "Focus", "New value", value, 0, 100, 2)
         if ok:
-            asyncio.ensure_future(self._set_focus_base_async(new_value))
+            self.run_background(self._set_focus_base_async, new_value)
 
     async def _set_focus_base_async(self, new_value: float) -> None:
         async with self.comm.proxy(self.module, IFocuser) as proxy:
@@ -81,14 +79,16 @@ class FocusWidget(BaseWidget, Ui_FocusWidget):
         value = self._focus_offset or 0.0
         new_value, ok = QtWidgets.QInputDialog.getDouble(self, "Focus offset", "New value", value, -5, 5, 2)
         if ok:
-            asyncio.ensure_future(self._set_focus_offset_async(new_value))
+            self.run_background(self._set_focus_offset_async, new_value)
 
     async def _set_focus_offset_async(self, new_value: float) -> None:
         async with self.comm.proxy(self.module, IFocuser) as proxy:
             await proxy.set_focus_offset(new_value)
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _reset_focus_offset(self) -> None:
+    def _reset_focus_offset(self) -> None:
+        self.run_background(self._do_reset_focus_offset)
+
+    async def _do_reset_focus_offset(self) -> None:
         async with self.comm.proxy(self.module, IFocuser) as proxy:
             await proxy.set_focus_offset(0.0)
 

--- a/pyobs_gui/roofwidget.py
+++ b/pyobs_gui/roofwidget.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
-import qasync  # type: ignore
 from PySide6 import QtCore  # type: ignore
 
 from pyobs.interfaces import IMotion, MotionState, IPointingAltAz, AltAzState
@@ -53,17 +52,23 @@ class RoofWidget(BaseWidget, Ui_RoofWidget):
         else:
             self.labelAzimuth.setText(f"{self._azimuth:.1f}°")
 
-    @qasync.asyncSlot()  # type: ignore
-    async def open_roof(self) -> None:
+    def open_roof(self) -> None:
+        self.run_background(self._open_roof)
+
+    async def _open_roof(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.init()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def close_roof(self) -> None:
+    def close_roof(self) -> None:
+        self.run_background(self._close_roof)
+
+    async def _close_roof(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.park()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def stop_roof(self) -> None:
+    def stop_roof(self) -> None:
+        self.run_background(self._stop_roof)
+
+    async def _stop_roof(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.stop_motion()

--- a/pyobs_gui/spectrographwidget.py
+++ b/pyobs_gui/spectrographwidget.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from typing import Any, TYPE_CHECKING
-import qasync  # type: ignore
 from PySide6 import QtCore  # type: ignore
 
 from pyobs.interfaces import IAbortable, IExposure, ExposureState
@@ -59,8 +58,10 @@ class SpectrographWidget(BaseWidget, Ui_SpectrographWidget):
         self.exposure_status = state.status
         self.signal_update_gui.emit()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def grab_spectrum(self) -> None:
+    def grab_spectrum(self) -> None:
+        self.run_background(self._grab_spectra)
+
+    async def _grab_spectra(self) -> None:
         broadcast = self.checkBroadcast.isChecked()
 
         # take the requested number of spectra; an exception (e.g. from a failed exposure,
@@ -72,10 +73,12 @@ class SpectrographWidget(BaseWidget, Ui_SpectrographWidget):
             self.exposures_left -= 1
             self.signal_update_gui.emit()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def abort(self) -> None:
+    def abort(self) -> None:
         # stop the sequence after the current spectrum finishes aborting
         self.exposures_left = 0
+        self.run_background(self._abort_sequence)
+
+    async def _abort_sequence(self) -> None:
         async with self.comm.proxy(self.module, IAbortable) as proxy:
             await proxy.abort()
 

--- a/pyobs_gui/statuswidget.py
+++ b/pyobs_gui/statuswidget.py
@@ -13,7 +13,7 @@ from pyobs.events import Event, ModuleOpenedEvent, ModuleClosedEvent
 from pyobs.interfaces import IModule, Interface
 from pyobs.utils.enums import ModuleState
 from pyobs.vfs import VirtualFileSystem
-from pyobs_gui.base import BaseWidget
+from pyobs_gui.base import BaseWidget, show_remote_error
 
 log = logging.getLogger(__name__)
 
@@ -131,8 +131,11 @@ class StatusItem(QtWidgets.QWidget):
 
     @qasync.asyncSlot()  # type: ignore
     async def button_clicked(self) -> None:
-        async with self.comm.proxy(self.name, IModule) as proxy:
-            await proxy.reset_error()
+        try:
+            async with self.comm.proxy(self.name, IModule) as proxy:
+                await proxy.reset_error()
+        except Exception as e:
+            await show_remote_error(self, e)
 
 
 class StateItem(QtCore.QObject):

--- a/pyobs_gui/telescopewidget.py
+++ b/pyobs_gui/telescopewidget.py
@@ -1,9 +1,7 @@
-import asyncio
 from enum import Enum
 from typing import Any
 
 import numpy as np
-import qasync  # type: ignore
 from PySide6 import QtWidgets, QtCore  # type: ignore
 from astropy.coordinates import SkyCoord, ICRS, AltAz, get_sun, EarthLocation
 from astroplan import Observer
@@ -473,9 +471,7 @@ class TelescopeWidget(BaseWidget, Ui_TelescopeWidget):
 
             if IPointingHelioprojective in self._interfaces and self.permitted("move_helioprojective"):
                 self.run_background(self._do_move_helioprojective, heliproj.Tx.degree, heliproj.Ty.degree)
-            elif IPointingHeliographicStonyhurst in self._interfaces and self.permitted(
-                "move_heliographic_stonyhurst"
-            ):
+            elif IPointingHeliographicStonyhurst in self._interfaces and self.permitted("move_heliographic_stonyhurst"):
                 stony = heliproj.transform_to(HeliographicStonyhurst)
                 # pyrefly: ignore [missing-attribute]
                 lon, lat = float(stony.lon.to(u.degree).value), float(stony.lat.to(u.degree).value)
@@ -517,18 +513,24 @@ class TelescopeWidget(BaseWidget, Ui_TelescopeWidget):
     # Motion control slots
     # -------------------------------------------------------------------------
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _init_telescope(self) -> None:
+    def _init_telescope(self) -> None:
+        self.run_background(self._do_init)
+
+    async def _do_init(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.init()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _park_telescope(self) -> None:
+    def _park_telescope(self) -> None:
+        self.run_background(self._do_park)
+
+    async def _do_park(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.park()
 
-    @qasync.asyncSlot()  # type: ignore
-    async def _stop_telescope(self) -> None:
+    def _stop_telescope(self) -> None:
+        self.run_background(self._do_stop)
+
+    async def _do_stop(self) -> None:
         async with self.comm.proxy(self.module, IMotion) as proxy:
             await proxy.stop_motion("ITelescope")
 
@@ -539,20 +541,20 @@ class TelescopeWidget(BaseWidget, Ui_TelescopeWidget):
     @QtCore.Slot()  # type: ignore
     def _set_offset(self) -> None:
         if self.sender() == self.buttonResetHorizontalOffsets:
-            asyncio.create_task(self._do_set_offsets_altaz(0.0, 0.0))
+            self.run_background(self._do_set_offsets_altaz, 0.0, 0.0)
         elif self.sender() == self.buttonResetEquatorialOffsets:
-            asyncio.create_task(self._do_set_offsets_radec(0.0, 0.0))
+            self.run_background(self._do_set_offsets_radec, 0.0, 0.0)
         else:
             new_value, ok = QtWidgets.QInputDialog.getDouble(self, "Set offset", 'New offset ["]', 0, -9999, 9999)
             if ok:
                 if self.sender() == self.buttonSetAltOffset:
-                    asyncio.create_task(self._do_set_offsets_altaz(new_value / 3600.0, self._off_az or 0.0))
+                    self.run_background(self._do_set_offsets_altaz, new_value / 3600.0, self._off_az or 0.0)
                 elif self.sender() == self.buttonSetAzOffset:
-                    asyncio.create_task(self._do_set_offsets_altaz(self._off_alt or 0.0, new_value / 3600.0))
+                    self.run_background(self._do_set_offsets_altaz, self._off_alt or 0.0, new_value / 3600.0)
                 elif self.sender() == self.buttonSetRaOffset:
-                    asyncio.create_task(self._do_set_offsets_radec(new_value / 3600.0, self._off_dec or 0.0))
+                    self.run_background(self._do_set_offsets_radec, new_value / 3600.0, self._off_dec or 0.0)
                 elif self.sender() == self.buttonSetDecOffset:
-                    asyncio.create_task(self._do_set_offsets_radec(self._off_ra or 0.0, new_value / 3600.0))
+                    self.run_background(self._do_set_offsets_radec, self._off_ra or 0.0, new_value / 3600.0)
 
     async def _do_set_offsets_altaz(self, alt: float, az: float) -> None:
         async with self.comm.proxy(self.module, IOffsetsAltAz) as proxy:

--- a/pyobs_gui/videowidget.py
+++ b/pyobs_gui/videowidget.py
@@ -3,7 +3,6 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
-import qasync  # type: ignore
 from astroplan import Observer
 from pyobs.comm import Comm
 from pyobs.interfaces import (
@@ -224,8 +223,10 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
             qp.loadFromData(image_data)
             self.widgetLiveView.setPixmap(qp)
 
-    @qasync.asyncSlot()  # type: ignore
-    async def grab_image(self) -> None:
+    def grab_image(self) -> None:
+        self.run_background(self._grab_image)
+
+    async def _grab_image(self) -> None:
         # set image format
         if IImageFormat in self._interfaces:
             image_format = ImageFormat[self.comboImageFormat.currentText()]  # type: ignore[attr-defined]
@@ -239,7 +240,7 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
         self.signal_update_gui.emit()
 
         # start exposures
-        asyncio.create_task(self._expose_task_func())
+        await self._expose_task_func()
 
     async def _expose_task_func(self) -> None:
         # get image type
@@ -266,22 +267,26 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
     def abort_sequence(self) -> None:
         self.exposures_left = 0
 
-    @qasync.asyncSlot()  # type: ignore
-    async def exposure_time_changed(self) -> None:
+    def exposure_time_changed(self) -> None:
         # get exp_time
         exp_time = self.spinExpTime.value()
 
         # set it
+        self.run_background(self._set_exposure_time, exp_time)
+
+    async def _set_exposure_time(self, exp_time: float) -> None:
         if IExposureTime in self._interfaces:
             async with self.comm.proxy(self.module, IExposureTime) as proxy:
                 await proxy.set_exposure_time(exp_time)
 
-    @qasync.asyncSlot()  # type: ignore
-    async def gain_changed(self) -> None:
+    def gain_changed(self) -> None:
         # get gain
         gain = self.spinGain.value()
 
         # set it
+        self.run_background(self._set_gain, gain)
+
+    async def _set_gain(self, gain: float) -> None:
         if IGain in self._interfaces:
             async with self.comm.proxy(self.module, IGain) as proxy:
                 await proxy.set_gain(gain)

--- a/specs/2026-08-20-gui-remote-call-error-handling.md
+++ b/specs/2026-08-20-gui-remote-call-error-handling.md
@@ -1,0 +1,224 @@
+# Plan: pyobs-gui — surface remote-call failures in messageboxes (issue #134)
+
+Status: proposed
+Issue: pyobs-gui#134
+
+## Problem
+
+Every user-triggered remote call (`async with self.comm.proxy(...) as proxy: await proxy.foo(...)`)
+can fail with a `pyobs.utils.exceptions.PyobsError` — domain errors from the module (`MoveError`,
+`GrabImageError`, `DeviceBusyError`, `NotSupportedError`, `InvalidArgumentError`, ...) or transport
+errors (`RemoteError`, `RemoteTimeoutError`, `ForbiddenError`). Most widget call sites swallow or
+ignore the exception today, so the operator gets no feedback and only finds out from the log (or not
+at all). Issue #134 asks for every user-triggered remote call to surface the failure in a messagebox,
+via the code path that already exists: `BaseWidget.run_background()`.
+
+## Current state (audited 2026-08-20)
+
+### Already handled — routed through `run_background()`
+
+`run_background()` → `_background_task()` (`base.py:296-318`) wraps the call in
+`except exc.PyobsError → show_error()`, `except Exception → log.exception + QAsyncMessageBox.warning`,
+plus optional button disable/enable. Already used by:
+
+- `filterwidget.py:69` — `set_filter` (proxy is created in the asyncSlot, then
+  `run_background(proxy.set_filter, ...)` is scheduled; works because `_ProxyContext.__aexit__` is a
+  no-op and the `Proxy` is cached by `Comm`, but stylistically the whole call should live inside the
+  background task — tidy-up below)
+- `modewidget.py:118` — `set_mode` (correct pattern: a nested `_do_set_mode()` owns the proxy)
+- `telescopewidget.py` — all `_do_move_*` / `_do_track_*` launched from `move()`
+- `compassmovewidget.py:32` — `__move_offset`
+
+### Not handled — bare `@qasync.asyncSlot()` that awaits `proxy.method()` directly
+
+An exception here only reaches the event loop's exception handler (one log line), never the user:
+
+- `roofwidget.py:56-69` — `open_roof` (`init`), `close_roof` (`park`), `stop_roof` (`stop_motion`)
+- `coolingwidget.py:50-55` — `buttonApply_clicked` (`set_cooling`)
+- `autofocuswidget.py:98-106` — `_run_auto_focus`, `_abort`
+- `autoguidingwidget.py:133-147` — `_start`, `_stop`, `_set_exposure_time`
+- `acquisitionwidget.py:150-158` — `_acquire`, `_abort`
+- `spectrographwidget.py:62-80` — `grab_spectrum` (loop of `datadisplay.grab_data`), `abort`
+- `telescopewidget.py:520-533` — `_init_telescope`, `_park_telescope`, `_stop_telescope`
+- `focuswidget.py:90-93` — `_reset_focus_offset`
+- `camerawidget.py:228,271,351` — `set_full_frame` (read-only capabilities fetch), `expose` (has two
+  ad-hoc `except Exception` → `QMessageBox.information` blocks, lines 277-282 and 291-295), `abort`
+- `videowidget.py:227-287` — `grab_image`, `exposure_time_changed`, `gain_changed`
+- `statuswidget.py:132-135` — `StatusItem.button_clicked` (`reset_error`); `StatusItem` is not a
+  `BaseWidget`, so it has no `run_background`
+
+### Fire-and-forget tasks — exceptions discarded at GC
+
+- `focuswidget.py:74,84` — `asyncio.ensure_future(self._set_focus_base_async(...))` /
+  `_set_focus_offset_async`
+- `telescopewidget.py:542-555` — `_set_offset` launches `_do_set_offsets_altaz` /
+  `_do_set_offsets_radec` via `asyncio.create_task`
+
+### Background polling — silently swallowed
+
+`base.py:292-294` — `_update_loop` catches `(exc.PyobsError, IndexError)` and just sleeps; every
+widget's `_update_func` failure is invisible (no log, no dialog).
+
+## Design
+
+### 1. Single code path: route every user-triggered remote call through `run_background()`
+
+Convert each affected `@qasync.asyncSlot()` handler into a plain (sync) method that (a) reads any
+widget state it needs (spinbox/checkbox values — cheap, must stay on the Qt thread and run before
+the task starts), then (b) calls `self.run_background(<async impl>, ...)`. The async impl owns the
+`async with self.comm.proxy(...)` block and the single `await proxy.method(...)` — nothing else.
+This is exactly the `modewidget.set_mode` pattern already in the codebase.
+
+```python
+# before
+@qasync.asyncSlot()
+async def open_roof(self) -> None:
+    async with self.comm.proxy(self.module, IMotion) as proxy:
+        await proxy.init()
+
+# after
+def open_roof(self) -> None:
+    self.run_background(self._open_roof)
+
+async def _open_roof(self) -> None:
+    async with self.comm.proxy(self.module, IMotion) as proxy:
+        await proxy.init()
+```
+
+No `@qasync.asyncSlot()` remains for any user-triggered remote call. Sync methods need no decorator;
+Qt connects to any callable and drops extra signal args (e.g. `valueChanged(int)` → no-arg method),
+which is exactly what the current no-arg asyncSlots already rely on.
+
+### 2. Fix `show_error()`
+
+Current (`base.py:320-323`): `title, message = err.split(":")` — breaks on any message containing
+":", e.g. `str(e) == "Cannot move: motor stalled at 12:30"` yields a nonsense title. Replace with
+the exception class name as the title and the full `str(exception)` as the message:
+
+```python
+async def show_error(self, exception: exc.PyobsError) -> None:
+    await QAsyncMessageBox.warning(self, type(exception).__name__, str(exception))
+```
+
+Keep the `warning` icon for all `PyobsError` (see Decisions).
+
+### 3. Shared error-display helper for non-`BaseWidget` callers
+
+`StatusItem.button_clicked` needs the same handling but `StatusItem` isn't a `BaseWidget`. Extract
+the display half of `_background_task`'s error handling into one reusable helper so there is
+genuinely a single code path:
+
+```python
+# base.py
+async def show_remote_error(parent: QtWidgets.QWidget, exception: Exception) -> None:
+    if isinstance(exception, exc.PyobsError):
+        await QAsyncMessageBox.warning(parent, type(exception).__name__, str(exception))
+    else:
+        log.exception("An error occurred.")
+        await QAsyncMessageBox.warning(parent, "Error", str(exception))
+```
+
+`_background_task` and `StatusItem.button_clicked` both delegate to it.
+
+### 4. `_update_loop()`: log, throttled, never a dialog
+
+Background polling failures must not pop a dialog per failed poll (spam). Replace the silent
+`except (exc.PyobsError, IndexError): sleep` with throttled logging — first failure, then every 60th
+(~once a minute at the 1 s poll interval), counter reset on success:
+
+```python
+async def _update_loop(self) -> None:
+    consecutive_failures = 0
+    while True:
+        try:
+            ...existing body...
+            consecutive_failures = 0
+        except (exc.PyobsError, IndexError) as e:
+            consecutive_failures += 1
+            if consecutive_failures == 1 or consecutive_failures % 60 == 0:
+                log.warning("Update of %s failed: %s", self.module, e)
+            await asyncio.sleep(1)
+```
+
+### 5. Fold camerawidget's ad-hoc `except Exception` blocks into the shared path
+
+Remove the two `try/except Exception: QMessageBox.information(...); return` blocks in `expose()`
+(lines 277-282, 291-295) and let `_background_task` surface failures. Behavior change: the dialog
+becomes a warning carrying the actual exception text instead of the generic "Could not set
+binning." / "Could not set window." — strictly more useful. The remaining expose steps are still
+skipped on failure, because the exception propagates and aborts the task (same as today's `return`).
+
+## Decisions (open questions from the issue)
+
+- **`show_error` icon/title**: title = exception class name, icon = `warning` for all `PyobsError`.
+  Rationale: every `PyobsError` — domain or transport — is an operator-actionable failure that can
+  simply be retried; `critical` in this codebase is reserved for pre-call checks that block the
+  action entirely ("Not permitted to …", "Invalid coordinates" — `QMessageBox.critical` in
+  `telescopewidget.move()`).
+- **`_update_loop`**: log + throttle, never a dialog (Design §4). User-triggered failures get the
+  dialog; background polling gets the log.
+- **camerawidget ad-hoc blocks**: folded into the shared path (Design §5).
+
+## Per-file change list
+
+All files under `pyobs_gui/`:
+
+1. `base.py` — `show_error()` title fix; extract `show_remote_error()`; `_update_loop()` throttled
+   logging.
+2. `roofwidget.py` — `open_roof` / `close_roof` / `stop_roof` → sync + `run_background`; drop the
+   `qasync` import if unused.
+3. `coolingwidget.py` — `buttonApply_clicked` → sync + `run_background`; read checkbox/spin values in
+   the sync slot.
+4. `autofocuswidget.py` — `_run_auto_focus` / `_abort` → sync + `run_background`.
+5. `autoguidingwidget.py` — `_start` / `_stop` / `_set_exposure_time` → sync + `run_background`; read
+   the spin value in the sync slot.
+6. `acquisitionwidget.py` — `_acquire` / `_abort` → sync + `run_background`.
+7. `spectrographwidget.py` — `grab_spectrum` / `abort` → sync + `run_background`. `abort` keeps
+   setting `exposures_left = 0` synchronously (stops the loop immediately even if the remote abort
+   fails); the grab loop (incl. `datadisplay.grab_data`) runs inside the background task.
+8. `telescopewidget.py` — `_init_telescope` / `_park_telescope` / `_stop_telescope` → sync +
+   `run_background`; `_set_offset` → `run_background(self._do_set_offsets_*, ...)` instead of
+   `asyncio.create_task`.
+9. `focuswidget.py` — `_set_focus_base` / `_set_focus_offset` → `run_background(...)` instead of
+   `asyncio.ensure_future`; `_reset_focus_offset` → sync + `run_background`.
+10. `camerawidget.py` — `expose` / `abort` / `set_full_frame` → sync + `run_background`; delete the
+    two ad-hoc `except Exception` blocks.
+11. `videowidget.py` — `grab_image` → sync + `run_background(self._expose_task_func)` instead of
+    `asyncio.create_task`; `exposure_time_changed` / `gain_changed` → sync + `run_background`.
+12. `statuswidget.py` — `StatusItem.button_clicked` → try/except delegating to `show_remote_error()`.
+
+`filterwidget.py` / `modewidget.py` / `compassmovewidget.py` need no behavior change; optionally tidy
+`filterwidget.set_filter` to create the proxy inside the background task (same pattern as
+`modewidget`).
+
+## Verification
+
+No pytest suite exists; verify by driving the real `GUI` module headlessly (offscreen Qt) against
+the existing `LocalComm` fixtures (`test/*.yaml`: `roof.yaml`, `telescope.yaml`, `camera.yaml`,
+`spectrograph.yaml`, `autofocus.yaml`, `guiding.yaml`, `acquisition.yaml`, `video.yaml`), per the
+`verify` skill recipe.
+
+For each converted widget:
+
+1. Open the fixture; show the window so `_init()` runs; wait for the widget to enable.
+2. Force the remote call to fail — e.g. monkeypatch the module's method (or the proxy) to raise
+   `exc.MoveError("...")` / `exc.RemoteError(...)`.
+3. Trigger the slot (call the sync method or `button.click()`).
+4. Assert: a `QAsyncMessageBox` appeared with the exception text (observe via `utils._live_dialogs`
+   or a patched `QAsyncMessageBox.warning` / `show_error` recording calls); no "Task exception was
+   never retrieved" warning; no exception reached the event loop handler; the button re-enables
+   afterwards (`_background_task`'s `finally`).
+
+For `_update_loop`: give a widget an `_update_func` that raises `exc.PyobsError`; assert one log
+line on first failure, no dialog, and throttled repeats.
+
+## Rollout / out of scope
+
+- pyobs-gui only; no config, API, or pyobs-core changes. Rollback = revert the widget edits.
+- Out of scope: `mainwindow.py` background tasks (`_check_warning_task`, `_client_connected`) — not
+  user-triggered; event-handler callbacks (`_on_new_data` etc.) — dispatched by comm, logged there;
+  `videowidget` MJPEG socket / `_init` failures — already logged; `statuswidget._add_module_details`
+  — already caught.
+- Follow-up candidates (noted, not planned): give `mainwindow._check_warning_task` the same
+  throttled-logging treatment; make `filterwidget.set_filter` proxy creation consistent with
+  `modewidget`.

--- a/specs/2026-08-20-gui-remote-call-error-handling.md
+++ b/specs/2026-08-20-gui-remote-call-error-handling.md
@@ -89,20 +89,27 @@ No `@qasync.asyncSlot()` remains for any user-triggered remote call. Sync method
 Qt connects to any callable and drops extra signal args (e.g. `valueChanged(int)` → no-arg method),
 which is exactly what the current no-arg asyncSlots already rely on.
 
-### 2. Fix `show_error()`
+### 2. Replace `show_error()` with the shared `show_remote_error()` helper
 
-Current (`base.py:320-323`): `title, message = err.split(":")` — breaks on any message containing
-":", e.g. `str(e) == "Cannot move: motor stalled at 12:30"` yields a nonsense title. Replace with
-the exception class name as the title and the full `str(exception)` as the message:
+`show_error()` (`base.py`) did `title, message = err.split(":")` — breaks on any message containing
+":", e.g. `str(e) == "Cannot move: motor stalled at 12:30"` yields a nonsense title. It is replaced
+by the shared `show_remote_error()` helper below: title = exception class name, body = the message
+only (`PyobsError.__str__` already prefixes the class name, so `str(exception)` would duplicate it
+— use `exception.message`):
 
 ```python
-async def show_error(self, exception: exc.PyobsError) -> None:
-    await QAsyncMessageBox.warning(self, type(exception).__name__, str(exception))
+async def show_remote_error(parent: QtWidgets.QWidget, exception: Exception) -> None:
+    if isinstance(exception, exc.PyobsError):
+        await QAsyncMessageBox.warning(parent, type(exception).__name__, exception.message or str(exception))
+    else:
+        log.exception("An error occurred.")
+        await QAsyncMessageBox.warning(parent, "Error", str(exception))
 ```
 
-Keep the `warning` icon for all `PyobsError` (see Decisions).
+Keep the `warning` icon for all `PyobsError` (see Decisions). `show_error()` and its never-emitted
+`_show_error` signal are removed (dead code after this change).
 
-### 3. Shared error-display helper for non-`BaseWidget` callers
+### 3. Non-`BaseWidget` callers use the same helper
 
 `StatusItem.button_clicked` needs the same handling but `StatusItem` isn't a `BaseWidget`. Extract
 the display half of `_background_task`'s error handling into one reusable helper so there is
@@ -150,7 +157,7 @@ skipped on failure, because the exception propagates and aborts the task (same a
 
 ## Decisions (open questions from the issue)
 
-- **`show_error` icon/title**: title = exception class name, icon = `warning` for all `PyobsError`.
+- **`show_remote_error` icon/title**: title = exception class name, icon = `warning` for all `PyobsError`.
   Rationale: every `PyobsError` — domain or transport — is an operator-actionable failure that can
   simply be retried; `critical` in this codebase is reserved for pre-call checks that block the
   action entirely ("Not permitted to …", "Invalid coordinates" — `QMessageBox.critical` in
@@ -163,7 +170,8 @@ skipped on failure, because the exception propagates and aborts the task (same a
 
 All files under `pyobs_gui/`:
 
-1. `base.py` — `show_error()` title fix; extract `show_remote_error()`; `_update_loop()` throttled
+1. `base.py` — replace `show_error()` with the `show_remote_error()` helper (drop the dead
+   `_show_error` signal); `_update_loop()` throttled
    logging.
 2. `roofwidget.py` — `open_roof` / `close_roof` / `stop_roof` → sync + `run_background`; drop the
    `qasync` import if unused.
@@ -205,7 +213,7 @@ For each converted widget:
    `exc.MoveError("...")` / `exc.RemoteError(...)`.
 3. Trigger the slot (call the sync method or `button.click()`).
 4. Assert: a `QAsyncMessageBox` appeared with the exception text (observe via `utils._live_dialogs`
-   or a patched `QAsyncMessageBox.warning` / `show_error` recording calls); no "Task exception was
+   or a patched `QAsyncMessageBox.warning` recording calls); no "Task exception was
    never retrieved" warning; no exception reached the event loop handler; the button re-enables
    afterwards (`_background_task`'s `finally`).
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -1,11 +1,18 @@
 # Design/planning docs
 
-This repo has no `specs/` structure of its own. Design docs, implementation plans, and ADRs that
-concern `pyobs-gui` — including ones actually implemented here — live in `pyobs-core`'s `specs/`
-tree instead (`specs/design/`, `specs/plans/`, `specs/adrs/`), each tagged with a `Repos:` line
-naming every repo it concerns. See `pyobs-core/CLAUDE.md`'s "Cross-repo docs" section.
+pyobs-gui keeps its own implementation plans in this directory (`YYYY-MM-DD-<slug>.md`), following
+the same conventions as `pyobs-core`'s `specs/` tree. Older design docs, implementation plans, and
+ADRs that concern `pyobs-gui` live in `pyobs-core`'s `specs/` tree instead (`specs/design/`,
+`specs/plans/`, `specs/adrs/`), each tagged with a `Repos:` line naming every repo it concerns. See
+`pyobs-core/CLAUDE.md`'s "Cross-repo docs" section.
 
-Relevant so far:
+## Local plans
+
+- `2026-08-20-gui-remote-call-error-handling.md` — proposed. Catch exceptions on remote method
+  calls and show them in a messagebox (issue #134): route every user-triggered remote call through
+  `run_background`, log throttled background failures.
+
+## Relevant from pyobs-core
 
 - `pyobs-core/specs/design/gui-standalone-binary.md` — big picture: shipping `pyobs-gui` as a
   single compiled binary that works across sites with no rebuild. Start here.

--- a/tests/test_camerawidget.py
+++ b/tests/test_camerawidget.py
@@ -47,7 +47,9 @@ async def test_expose_uses_server_side_sequence_when_broadcasting(qapp) -> None:
     widget.checkBroadcast.setChecked(True)
     widget.spinCount.setValue(3)
 
-    await widget.expose()
+    # expose() is now a sync slot that routes through run_background(); exercise the async
+    # sequence logic directly here (the slot -> run_background routing is covered end-to-end)
+    await widget._do_expose()
 
     proxy.grab_sequence.assert_awaited_once_with(3, True)
     widget.datadisplay.grab_data.assert_not_called()
@@ -64,7 +66,7 @@ async def test_expose_falls_back_to_client_side_loop_when_not_broadcasting(qapp)
     widget.checkBroadcast.setChecked(False)
     widget.spinCount.setValue(2)
 
-    await widget.expose()
+    await widget._do_expose()
 
     proxy.grab_sequence.assert_not_called()
     assert widget.datadisplay.grab_data.await_count == 2
@@ -78,7 +80,7 @@ async def test_expose_falls_back_when_module_has_no_data_sequence_support(qapp) 
     widget.checkBroadcast.setChecked(True)
     widget.spinCount.setValue(1)
 
-    await widget.expose()
+    await widget._do_expose()
 
     assert widget.datadisplay.grab_data.await_count == 1
     widget.datadisplay.grab_data.assert_awaited_with(True)

--- a/tests/test_videowidget.py
+++ b/tests/test_videowidget.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pyobs.utils import exceptions as exc
+from pyobs_gui.videowidget import VideoWidget
+
+
+@pytest.mark.asyncio
+async def test_grab_image_awaits_expose_task_and_surfaces_failure(qapp) -> None:
+    """grab_image() must run the expose sequence as an awaited task so failures surface (issue
+    #134: it used to be fire-and-forget via asyncio.create_task, so an exception during the
+    sequence was discarded at GC and the operator got no feedback)."""
+    widget = VideoWidget()
+    widget.modules = ["cam"]
+    # empty _interfaces -> no IImageFormat/IImageType proxy calls, straight into the grab loop
+    widget.datadisplay.grab_data = AsyncMock(side_effect=exc.GrabImageError("exposure failed"))
+    widget.spinCount.setValue(2)
+
+    with pytest.raises(exc.GrabImageError):
+        await widget._grab_image()
+
+    # the grab failed before the decrement, so the loop state is untouched
+    assert widget.exposures_left == 2
+    widget.close()
+
+
+@pytest.mark.asyncio
+async def test_grab_image_sets_exposure_count_before_grabbing(qapp) -> None:
+    widget = VideoWidget()
+    widget.modules = ["cam"]
+    widget.datadisplay.grab_data = AsyncMock(return_value="img.fits")
+    widget.spinCount.setValue(3)
+
+    await widget._grab_image()
+
+    assert widget.datadisplay.grab_data.await_count == 3
+    widget.close()


### PR DESCRIPTION
## What

Fixes #134. Every user-triggered remote call (`async with self.comm.proxy(...) as proxy: await proxy.foo(...)`) can fail with a `pyobs.utils.exceptions.PyobsError` — domain errors (`MoveError`, `GrabImageError`, `DeviceBusyError`, ...) or transport errors (`RemoteError`, `RemoteTimeoutError`, `ForbiddenError`). Most widget call sites swallowed or ignored the exception, so the operator got no feedback. This PR routes **all** of them through the one code path that already handled this correctly: `BaseWidget.run_background()` → `_background_task()`.

## Changes

**`base.py`** — single shared error path:
- New `show_remote_error(parent, exception)` helper: `PyobsError` → warning box titled with the exception class name; any other `Exception` → logged + plain warning box. Used by `_background_task()` and by non-`BaseWidget` callers (`StatusItem`).
- `show_error()` no longer does the fragile `str(e).split(":")` title hack — title is now `type(exception).__name__`.
- `_update_loop()` no longer silently swallows `(PyobsError, IndexError)`: logs the first failure, then every 60th (~once/min at the 1 s poll), never a dialog (background polling must not spam).

**Converted from bare `@qasync.asyncSlot()` → sync slot + `run_background()`** (roof, cooling, autofocus, autoguiding, acquisition, spectrograph, telescope init/park/stop, focus reset-offset, camera expose/abort/set_full_frame, video, status):
- `roofwidget.py` — `open_roof` / `close_roof` / `stop_roof`
- `coolingwidget.py` — `buttonApply_clicked`
- `autofocuswidget.py` — `_run_auto_focus` / `_abort`
- `autoguidingwidget.py` — `_start` / `_stop` / `_set_exposure_time`
- `acquisitionwidget.py` — `_acquire` / `_abort`
- `spectrographwidget.py` — `grab_spectrum` / `abort`
- `telescopewidget.py` — `_init_telescope` / `_park_telescope` / `_stop_telescope`
- `focuswidget.py` — `_reset_focus_offset`
- `camerawidget.py` — `expose` / `abort` / `set_full_frame`; the two ad-hoc `except Exception → QMessageBox.information("Could not set binning/window.")` blocks are removed in favor of the shared path (dialog now carries the actual error text)
- `videowidget.py` — `grab_image` / `exposure_time_changed` / `gain_changed`
- `statuswidget.py` — `StatusItem.button_clicked` (`reset_error`) now catches and delegates to `show_remote_error()`

**Fire-and-forget tasks → `run_background()`** (exceptions were discarded at GC):
- `focuswidget.py` — `asyncio.ensure_future(...)` → `run_background(...)`
- `telescopewidget.py` — `_set_offset`'s `asyncio.create_task(...)` → `run_background(...)`

**Cleanup:**
- `filterwidget.py` — `set_filter` now creates the proxy inside the background task (same pattern as `modewidget`), and the `QInputDialog` moved out of the async context
- `datadisplaywidget.py` — removed an unused `TYPE_CHECKING` import that fails current ruff (pre-existing on develop)
- `tests/test_camerawidget.py` — updated for the now-sync `expose()` (exercises `_do_expose()` directly; the slot → `run_background` routing is covered by the E2E harness)
- `specs/2026-08-20-gui-remote-call-error-handling.md` — implementation plan

## Verification

Headless E2E (offscreen Qt + `LocalComm` fixtures, per the `verify` skill):
- `roof.yaml`: `open_roof`/`close_roof` failing (`MoveError`/`ParkError`) → `QAsyncMessageBox` appears with class-name title + message ✓
- `camera.yaml`: `expose` failing at `set_binning` (`GrabImageError`) → dialog, sequence aborted ✓
- Every converted slot (autofocus, autoguiding, acquisition, cooling, focus, spectrograph, telescope, camera, video, status) with a failing remote call → dialog ✓
- `_update_loop` with a failing `_update_func` → exactly 1 throttled log line in ~2.5 s, zero dialogs ✓
- `pytest tests/` → 30 passed; `ruff check` (0.16.2) and `pyrefly check` clean; black 25.1.0 clean

Notes: black 25.1.0 also normalized two pre-existing lines in `autofocuswidget.py` / `telescopewidget.py` (both files were already black-non-compliant on develop). Background polling failures are logged, not dialogs — dialog spam from a repeatedly failing poll was deliberately avoided per the issue's open question.