### PR TITLE
feat(videowidget): send Authorization header on raw-socket MJPEG stream

### DIFF
--- a/pyobs_gui/videowidget.py
+++ b/pyobs_gui/videowidget.py
@@ -81,6 +81,10 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
         self.socket: QtNetwork.QAbstractSocket | None = None
         self.scheme: str | None = None
 
+        # Authorization header for the raw-socket stream request, taken from the
+        # HttpFile the widget opens in _init (None when the VFS root configures no token)
+        self._auth_header: str | None = None
+
         # whether the HTTP response headers of the current stream connection have
         # been stripped from self.buffer yet (see _received_data)
         self._headers_received = False
@@ -140,6 +144,10 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
         if not isinstance(video_file, HttpFile):
             log.error("VFS path to video of module %s must be an HttpFile.", self.module)
             return
+
+        # keep the Authorization header (Bearer token) for the raw-socket stream request --
+        # HttpFile sends it itself for VFS reads, but the stream bypasses HttpFile entirely
+        self._auth_header = video_file.headers.get("Authorization")
 
         # parse URL
         o = urlparse(video_file.url)
@@ -204,7 +212,9 @@ class VideoWidget(BaseWidget, Ui_VideoWidget):
             # as the plain MJPEG byte stream (with Connection: close, which just means the
             # stream runs until the client disconnects).
             self.socket.write(
-                b"GET %s HTTP/1.0\r\nHost: %s\r\n\r\n" % (bytes(self.path, "UTF-8"), bytes(host_header, "UTF-8"))
+                b"GET %s HTTP/1.0\r\nHost: %s\r\n" % (bytes(self.path, "UTF-8"), bytes(host_header, "UTF-8"))
+                + (b"Authorization: %s\r\n" % bytes(self._auth_header, "UTF-8") if self._auth_header else b"")
+                + b"\r\n"
             )
             # new connection: the next bytes start with the HTTP response headers
             self._headers_received = False

--- a/tests/test_videowidget.py
+++ b/tests/test_videowidget.py
@@ -1,9 +1,22 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from pyobs.utils import exceptions as exc
 from pyobs_gui.videowidget import VideoWidget
+
+
+def _widget_with_stream_socket() -> tuple[VideoWidget, MagicMock]:
+    """VideoWidget with a mocked raw stream socket, skipping _init."""
+    widget = VideoWidget()
+    widget._initialized = True
+    widget.host = "localhost"
+    widget.port = 37077
+    widget.path = "/webcam/video.mjpg"
+    widget.scheme = "http"
+    socket = MagicMock()
+    widget.socket = socket
+    return widget, socket
 
 
 @pytest.mark.asyncio
@@ -35,4 +48,35 @@ async def test_grab_image_sets_exposure_count_before_grabbing(qapp) -> None:
     await widget._grab_image()
 
     assert widget.datadisplay.grab_data.await_count == 3
+    widget.close()
+
+
+# ── raw-socket stream auth ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_show_event_sends_authorization_header_when_token_configured(qapp) -> None:
+    """With an HttpFile carrying a token, the raw-socket GET must include Authorization."""
+    widget, socket = _widget_with_stream_socket()
+    widget._auth_header = "Bearer secret"
+
+    await widget._showEvent(MagicMock())
+
+    written = socket.write.call_args[0][0]
+    assert written.startswith(b"GET /webcam/video.mjpg HTTP/1.0\r\nHost: localhost:37077\r\n")
+    assert b"Authorization: Bearer secret\r\n" in written
+    assert written.endswith(b"\r\n")
+    widget.close()
+
+
+@pytest.mark.asyncio
+async def test_show_event_sends_no_authorization_header_without_token(qapp) -> None:
+    """Without a token, the bytes written to the socket are unchanged from today."""
+    widget, socket = _widget_with_stream_socket()
+    widget._auth_header = None
+
+    await widget._showEvent(MagicMock())
+
+    written = socket.write.call_args[0][0]
+    assert written == b"GET /webcam/video.mjpg HTTP/1.0\r\nHost: localhost:37077\r\n\r\n"
     widget.close()


### PR DESCRIPTION
pyobs-gui half of `specs/plans/2026-08-21-basevideo-http-token-auth.md` (indexed in this repo at `specs/`).

## What

`VideoWidget` opens the MJPEG video URL as an `HttpFile` in `_init`, but streams it over a raw `QTcpSocket`/`QSslSocket` with a hand-written GET that currently sends **no** auth. Once the server side (`BaseVideo`, pyobs-core PR #799) enforces a shared token, that request gets a `401` which the MJPEG parser never surfaces (it strips response headers and finds no `--jpgboundary`).

- `_init`: after the `HttpFile` type check, store `self._auth_header = video_file.headers.get("Authorization")` (None when the VFS root configures no token).
- `_showEvent`: append `Authorization: <value>\r\n` to the raw-socket GET when set; bytes written are unchanged when unset.

Depends on the new public `HttpFile.headers` property (pyobs-core PR #799).

## Tests

`tests/test_videowidget.py`: with a token the written GET includes `Authorization: Bearer <token>`; without a token the written bytes are byte-identical to today.

## ⚠️ Coupling — land both halves together

- **This PR** (pyobs-gui): the `VideoWidget` consumer change.
- **Companion PR** `pyobs/pyobs-core` #799: server-side `BaseVideo` token/cookie auth + `HttpFile.headers`.

With `token` set on a webcam, the GUI live view breaks until this lands — merge both PRs together.